### PR TITLE
Add a Dockerfile for testing with Node 12

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -5,6 +5,15 @@ reviewers: 1
 # the tests to run at part of the image build step
 docker:
   publish: false
+  builds:
+    - dockerfile: Dockerfile
+      docker_repo: mocha-pod:node-latest
+      path: .
+      publish: false
+    - dockerfile: Dockerfile.node-12
+      docker_repo: mocha-pod:node-12
+      publish: false
+      path: .
 
 # Publish npm module (TODO) but do not test
 # as the tests are ran with the docker build

--- a/Dockerfile.node-12
+++ b/Dockerfile.node-12
@@ -1,0 +1,32 @@
+FROM node:12-alpine as build
+
+WORKDIR /usr/src/app
+
+COPY package.json ./
+
+# Setup dependencies
+RUN npm install
+
+# Copy all files necessary for running the tests to the
+# test stage
+COPY tsconfig.json ./
+COPY tsconfig.release.json ./
+COPY lib ./lib
+
+# Include the test directory in this stage
+COPY tests ./tests
+
+# Do not forget to copy mocha-pod config
+COPY .mochapodrc.yml ./
+
+# Set the environment variable globally to use
+# this image for development of mocha-pod
+ENV MOCHAPOD_SKIP_SETUP=1
+
+FROM build as testing
+
+# Comment the next line if you want to run the tests as a separate
+# container instead of during the image build step.
+# Make sure you also have set the  `buildOnly` to `false` inside
+# .mochapodrc.yml
+RUN MOCHAPOD_SKIP_SETUP=1 npm run test


### PR DESCRIPTION
A bunch of our codebase has yet to be upgraded to latest Node.
This ensures this module does not break compatibility with this older
version.

Change-type: patch