### PR TITLE
Add additional file configuration options to testfs

### DIFF
--- a/.mochapodrc.yml
+++ b/.mochapodrc.yml
@@ -19,3 +19,5 @@ buildOnly: true
 testfs:
   filesystem:
     /etc/unused.conf: 'just for testing'
+    /etc/extra.conf:
+      from: tests/data/extra.conf

--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -14,12 +14,33 @@
 
 ### Properties
 
+- [basedir](TestFs.Config.md#basedir)
 - [cleanup](TestFs.Config.md#cleanup)
 - [filesystem](TestFs.Config.md#filesystem)
 - [keep](TestFs.Config.md#keep)
 - [rootdir](TestFs.Config.md#rootdir)
 
 ## Properties
+
+### <a id="basedir" name="basedir"></a> basedir
+
+• `Readonly` **basedir**: `string`
+
+Directory to use as base for search when calling [from](TestFs.TestFs.md#from)
+
+**`Default Value`**
+
+given by the configuration in `.mochapodrc.yml`
+
+#### Inherited from
+
+[Opts](TestFs.Opts.md).[basedir](TestFs.Opts.md#basedir)
+
+#### Defined in
+
+[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L65)
+
+___
 
 ### <a id="cleanup" name="cleanup"></a> cleanup
 
@@ -39,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:38](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L38)
+[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L89)
 
 ___
 
@@ -55,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:68](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L68)
+[testfs/types.ts:119](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L119)
 
 ___
 
@@ -77,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:29](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L29)
+[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L80)
 
 ___
 
@@ -97,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L21)
+[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L72)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -32,4 +32,4 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:83](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L83)
+[testfs/types.ts:134](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L134)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -28,7 +28,7 @@ Location of the backup file
 
 #### Defined in
 
-[testfs/types.ts:50](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L50)
+[testfs/types.ts:101](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L101)
 
 ## Methods
 
@@ -48,4 +48,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:59](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L59)
+[testfs/types.ts:110](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L110)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -1,0 +1,54 @@
+[mocha-pod](../README.md) / [Exports](../modules.md) / [TestFs](../modules/TestFs.md) / FileOpts
+
+# Interface: FileOpts
+
+[TestFs](../modules/TestFs.md).FileOpts
+
+Generic file options
+
+## Hierarchy
+
+- **`FileOpts`**
+
+  ↳ [`FileSpec`](TestFs.FileSpec.md)
+
+  ↳ [`FileRef`](TestFs.FileRef.md)
+
+## Table of contents
+
+### Properties
+
+- [atime](TestFs.FileOpts.md#atime)
+- [mtime](TestFs.FileOpts.md#mtime)
+
+## Properties
+
+### <a id="atime" name="atime"></a> atime
+
+• **atime**: `Date`
+
+Last access time for the file.
+
+**`Default Value`**
+
+`new Date()`
+
+#### Defined in
+
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L21)
+
+___
+
+### <a id="mtime" name="mtime"></a> mtime
+
+• **mtime**: `Date`
+
+Last modification time for the file.
+
+**`Default Value`**
+
+`new Date()`
+
+#### Defined in
+
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L28)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -1,0 +1,75 @@
+[mocha-pod](../README.md) / [Exports](../modules.md) / [TestFs](../modules/TestFs.md) / FileRef
+
+# Interface: FileRef
+
+[TestFs](../modules/TestFs.md).FileRef
+
+Utility interface to indicate that a test file contents must
+be loaded from an existing file in the filesystem
+
+## Hierarchy
+
+- [`FileOpts`](TestFs.FileOpts.md)
+
+  ↳ **`FileRef`**
+
+## Table of contents
+
+### Properties
+
+- [atime](TestFs.FileRef.md#atime)
+- [from](TestFs.FileRef.md#from)
+- [mtime](TestFs.FileRef.md#mtime)
+
+## Properties
+
+### <a id="atime" name="atime"></a> atime
+
+• **atime**: `Date`
+
+Last access time for the file.
+
+**`Default Value`**
+
+`new Date()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[atime](TestFs.FileOpts.md#atime)
+
+#### Defined in
+
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L21)
+
+___
+
+### <a id="from" name="from"></a> from
+
+• **from**: `string`
+
+Absolute or relative path to read the file from. If a relative
+path is given, `process.cwd()` will be used as basedir
+
+#### Defined in
+
+[testfs/types.ts:47](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L47)
+
+___
+
+### <a id="mtime" name="mtime"></a> mtime
+
+• **mtime**: `Date`
+
+Last modification time for the file.
+
+**`Default Value`**
+
+`new Date()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[mtime](TestFs.FileOpts.md#mtime)
+
+#### Defined in
+
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L28)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -1,0 +1,73 @@
+[mocha-pod](../README.md) / [Exports](../modules.md) / [TestFs](../modules/TestFs.md) / FileSpec
+
+# Interface: FileSpec
+
+[TestFs](../modules/TestFs.md).FileSpec
+
+Generic file options
+
+## Hierarchy
+
+- [`FileOpts`](TestFs.FileOpts.md)
+
+  ↳ **`FileSpec`**
+
+## Table of contents
+
+### Properties
+
+- [atime](TestFs.FileSpec.md#atime)
+- [contents](TestFs.FileSpec.md#contents)
+- [mtime](TestFs.FileSpec.md#mtime)
+
+## Properties
+
+### <a id="atime" name="atime"></a> atime
+
+• **atime**: `Date`
+
+Last access time for the file.
+
+**`Default Value`**
+
+`new Date()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[atime](TestFs.FileOpts.md#atime)
+
+#### Defined in
+
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L21)
+
+___
+
+### <a id="contents" name="contents"></a> contents
+
+• **contents**: [`FileContents`](../modules/TestFs.md#filecontents)
+
+Contents of the file
+
+#### Defined in
+
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L35)
+
+___
+
+### <a id="mtime" name="mtime"></a> mtime
+
+• **mtime**: `Date`
+
+Last modification time for the file.
+
+**`Default Value`**
+
+`new Date()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[mtime](TestFs.FileOpts.md#mtime)
+
+#### Defined in
+
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L28)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -14,11 +14,28 @@
 
 ### Properties
 
+- [basedir](TestFs.Opts.md#basedir)
 - [cleanup](TestFs.Opts.md#cleanup)
 - [keep](TestFs.Opts.md#keep)
 - [rootdir](TestFs.Opts.md#rootdir)
 
 ## Properties
+
+### <a id="basedir" name="basedir"></a> basedir
+
+• `Readonly` **basedir**: `string`
+
+Directory to use as base for search when calling [from](TestFs.TestFs.md#from)
+
+**`Default Value`**
+
+given by the configuration in `.mochapodrc.yml`
+
+#### Defined in
+
+[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L65)
+
+___
 
 ### <a id="cleanup" name="cleanup"></a> cleanup
 
@@ -34,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:38](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L38)
+[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L89)
 
 ___
 
@@ -52,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:29](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L29)
+[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L80)
 
 ___
 
@@ -68,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L21)
+[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L72)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,13 +33,15 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L103)
+[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L154)
 
 ## Table of contents
 
 ### Methods
 
 - [config](TestFs.TestFs.md#config)
+- [file](TestFs.TestFs.md#file)
+- [from](TestFs.TestFs.md#from)
 - [leftovers](TestFs.TestFs.md#leftovers)
 - [restore](TestFs.TestFs.md#restore)
 
@@ -61,7 +63,55 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:110](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L110)
+[testfs/types.ts:161](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L161)
+
+___
+
+### <a id="file" name="file"></a> file
+
+▸ **file**(`f`): [`FileSpec`](TestFs.FileSpec.md)
+
+Create a file specification from a partial file description
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `f` | `string` \| `Buffer` \| [`WithOptional`](../modules/TestFs.md#withoptional)<[`FileSpec`](TestFs.FileSpec.md), keyof [`FileOpts`](TestFs.FileOpts.md)\> | file contents or partial file specification |
+
+#### Returns
+
+[`FileSpec`](TestFs.FileSpec.md)
+
+full file specification with defaults set
+
+#### Defined in
+
+[testfs/types.ts:186](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L186)
+
+___
+
+### <a id="from" name="from"></a> from
+
+▸ **from**(`f`): [`FileRef`](TestFs.FileRef.md)
+
+Create a file reference to an existing file
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `f` | `string` \| [`WithOptional`](../modules/TestFs.md#withoptional)<[`FileRef`](TestFs.FileRef.md), keyof [`FileOpts`](TestFs.FileOpts.md)\> | absolute or relative file path to create the reference from, if a relative path is given, `process.cwd()` will be            used as basedir. This parameter can also be a partial FileRef specification |
+
+#### Returns
+
+[`FileRef`](TestFs.FileRef.md)
+
+full file reference specification with defaults set
+
+#### Defined in
+
+[testfs/types.ts:195](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L195)
 
 ___
 
@@ -81,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:127](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L127)
+[testfs/types.ts:178](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L178)
 
 ___
 
@@ -100,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:118](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L118)
+[testfs/types.ts:169](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L169)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L103)
+[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L154)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -46,13 +46,13 @@ Renames and re-exports [Config](MochaPod.md#config)
 | `logging` | `string` | Log namespaces to enable. This can also be controlled via the `DEBUG` env var.  See https://github.com/debug-js/debug  **`Default Value`**  `'mocha-pod,mocha-pod:error'` |
 | `projectName` | `string` | Name of the project where mocha-pod is being ran on. By default it will get the name from `package.json` at `basedir`, if it does not exist, it will use `mocha-pod-testing` |
 | `testCommand` | `string`[] | Test command to use when running tests within a container. This will only be used if `buildOnly` is set to `false`.  **`Default Value`**  `["npm", "run", "test"]` |
-| `testfs` | `Partial`<[`Config`](../interfaces/TestFs.Config.md)\> | TestFs configuration to be used globally for all tests  **`Default Value`**  `{}` |
+| `testfs` | `Partial`<`Omit`<[`Config`](../interfaces/TestFs.Config.md), ``"basedir"``\>\> | TestFs configuration to be used globally for all tests.  **`Default Value`**  `{}` |
 
 #### Defined in
 
-[config.ts:174](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/config.ts#L174)
+[config.ts:174](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/config.ts#L174)
 
-[config.ts:8](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/config.ts#L8)
+[config.ts:8](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/config.ts#L8)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:174](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/config.ts#L174)
+[config.ts:174](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/config.ts#L174)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -14,12 +14,17 @@
 - [Directory](../interfaces/TestFs.Directory.md)
 - [Disabled](../interfaces/TestFs.Disabled.md)
 - [Enabled](../interfaces/TestFs.Enabled.md)
+- [FileOpts](../interfaces/TestFs.FileOpts.md)
+- [FileRef](../interfaces/TestFs.FileRef.md)
+- [FileSpec](../interfaces/TestFs.FileSpec.md)
 - [Opts](../interfaces/TestFs.Opts.md)
 - [TestFs](../interfaces/TestFs.TestFs.md)
 
 ### Type Aliases
 
 - [File](TestFs.md#file)
+- [FileContents](TestFs.md#filecontents)
+- [WithOptional](TestFs.md#withoptional)
 
 ## References
 
@@ -31,11 +36,39 @@ Re-exports [testfs](../modules.md#testfs)
 
 ### <a id="file" name="file"></a> File
 
-Ƭ **File**: `string` \| `Buffer`
-
-Describe a file contents and configuration
-options.
+Ƭ **File**: [`FileContents`](TestFs.md#filecontents) \| [`FileSpec`](../interfaces/TestFs.FileSpec.md) \| [`FileRef`](../interfaces/TestFs.FileRef.md)
 
 #### Defined in
 
-[testfs/types.ts:5](https://github.com/balena-io-modules/mocha-pod/blob/66ae657/lib/testfs/types.ts#L5)
+[testfs/types.ts:50](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L50)
+
+___
+
+### <a id="filecontents" name="filecontents"></a> FileContents
+
+Ƭ **FileContents**: `string` \| `Buffer`
+
+Describe a file contents
+
+#### Defined in
+
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L10)
+
+___
+
+### <a id="withoptional" name="withoptional"></a> WithOptional
+
+Ƭ **WithOptional**<`T`, `K`\>: `Omit`<`T`, `K`\> & `Partial`<`Pick`<`T`, `K`\>\>
+
+Utility type to mark only some properties of a given type as optional
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | `T` |
+| `K` | extends keyof `T` |
+
+#### Defined in
+
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L4)

--- a/lib/attach/hooks.ts
+++ b/lib/attach/hooks.ts
@@ -49,7 +49,7 @@ export const mochaHooks = {
 
 		// Read config and set testfs default configuration
 		const config = await Config();
-		testfs.config(config.testfs);
+		testfs.config({ basedir: config.basedir, ...config.testfs });
 		logger.debug('Using Config', JSON.stringify(config, null, 2));
 	},
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -92,11 +92,11 @@ export type Config = {
 	testCommand: string[];
 
 	/**
-	 * TestFs configuration to be used globally for all tests
+	 * TestFs configuration to be used globally for all tests.
 	 *
 	 * @defaultValue `{}`
 	 */
-	testfs: Partial<TestFs.Config>;
+	testfs: Partial<Omit<TestFs.Config, 'basedir'>>;
 
 	// Leave the type open so additional keys can be set
 	[key: string]: any;

--- a/lib/testfs/testfs.ts
+++ b/lib/testfs/testfs.ts
@@ -7,7 +7,7 @@ import logger from '../logger';
 import { nanoid } from 'nanoid';
 
 import { createReadStream, createWriteStream, promises as fs } from 'fs';
-import { flatten, replace } from './utils';
+import { flatten, replace, fileRef, fileSpec } from './utils';
 
 import { Config, Directory, Disabled, Enabled, Opts, TestFs } from './types';
 
@@ -197,5 +197,7 @@ export const testfs: TestFs = Object.assign(build, {
 	config,
 	restore,
 	leftovers,
+	file: fileSpec,
+	from: fileRef,
 });
 export default testfs;

--- a/lib/testfs/testfs.ts
+++ b/lib/testfs/testfs.ts
@@ -9,7 +9,17 @@ import { nanoid } from 'nanoid';
 import { createReadStream, createWriteStream, promises as fs } from 'fs';
 import { flatten, replace, fileRef, fileSpec } from './utils';
 
-import { Config, Directory, Disabled, Enabled, Opts, TestFs } from './types';
+import {
+	Config,
+	Directory,
+	Disabled,
+	Enabled,
+	Opts,
+	TestFs,
+	WithOptional,
+	FileRef,
+	FileOpts,
+} from './types';
 
 class TestFsLocked extends Error {}
 
@@ -61,6 +71,7 @@ let defaults: Config = {
 	keep: [],
 	cleanup: [],
 	rootdir: '/',
+	basedir: process.cwd(),
 };
 
 /**
@@ -198,6 +209,7 @@ export const testfs: TestFs = Object.assign(build, {
 	restore,
 	leftovers,
 	file: fileSpec,
-	from: fileRef,
+	from: (f: string | WithOptional<FileRef, keyof FileOpts>) =>
+		fileRef(f, defaults.basedir),
 });
 export default testfs;

--- a/lib/testfs/types.ts
+++ b/lib/testfs/types.ts
@@ -1,8 +1,53 @@
 /**
- * Describe a file contents and configuration
- * options.
+ * Utility type to mark only some properties of a given type as optional
  */
-export type File = string | Buffer;
+export type WithOptional<T, K extends keyof T> = Omit<T, K> &
+	Partial<Pick<T, K>>;
+
+/**
+ * Describe a file contents
+ */
+export type FileContents = string | Buffer;
+
+/**
+ * Generic file options
+ */
+export interface FileOpts {
+	/**
+	 * Last access time for the file.
+	 *
+	 * @defaultValue `new Date()`
+	 */
+	atime: Date;
+
+	/**
+	 * Last modification time for the file.
+	 *
+	 * @defaultValue `new Date()`
+	 */
+	mtime: Date;
+}
+
+export interface FileSpec extends FileOpts {
+	/**
+	 * Contents of the file
+	 */
+	contents: FileContents;
+}
+
+/**
+ * Utility interface to indicate that a test file contents must
+ * be loaded from an existing file in the filesystem
+ */
+export interface FileRef extends FileOpts {
+	/**
+	 * Absolute or relative path to read the file from. If a relative
+	 * path is given, `process.cwd()` will be used as basedir
+	 */
+	from: string;
+}
+
+export type File = FileContents | FileSpec | FileRef;
 
 /**
  * A directory is a recursive data structure of
@@ -125,4 +170,21 @@ export interface TestFs {
 	 * safe to run the setup.
 	 */
 	leftovers(): Promise<string[]>;
+
+	/**
+	 * Create a file specification from a partial file description
+	 *
+	 * @param f - file contents or partial file specification
+	 * @return full file specification with defaults set
+	 */
+	file(f: string | Buffer | WithOptional<FileSpec, keyof FileOpts>): FileSpec;
+
+	/**
+	 * Create a file reference to an existing file
+	 *
+	 * @param f - absolute or relative file path to create the reference from, if a relative path is given, `process.cwd()` will be
+	 *            used as basedir. This parameter can also be a partial FileRef specification
+	 * @return full file reference specification with defaults set
+	 */
+	from(f: string | WithOptional<FileRef, keyof FileOpts>): FileRef;
 }

--- a/lib/testfs/types.ts
+++ b/lib/testfs/types.ts
@@ -59,6 +59,12 @@ export interface Directory {
 
 export interface Opts {
 	/**
+	 * Directory to use as base for search when calling {@link TestFs.from}
+	 * @defaultValue given by the configuration in `.mochapodrc.yml`
+	 */
+	readonly basedir: string;
+
+	/**
 	 * Directory to use as base for the directory specification and glob search.
 	 *
 	 * @defaultValue `/`

--- a/lib/testfs/utils.spec.ts
+++ b/lib/testfs/utils.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '~/testing';
 
 import { promises as fs } from 'fs';
 import * as mock from 'mock-fs';
-import { dir, flatten, replace } from './utils';
+import { dir, flatten, replace, fileRef, fileSpec } from './utils';
 
 describe('testfs/utils: unit tests', function () {
 	describe('dir', () => {
@@ -196,7 +196,7 @@ describe('testfs/utils: unit tests', function () {
 		});
 
 		it('creates parent directory if it does not exist', async () => {
-			mock({ '/etc': {} });
+			mock({ '/': {} });
 
 			await replace(
 				{
@@ -259,6 +259,108 @@ describe('testfs/utils: unit tests', function () {
 			expect(
 				await fs.readFile('/etc/service-b/subdir/b.conf', 'utf8'),
 			).to.equal('SECOND FILE');
+
+			mock.restore();
+		});
+
+		it('uses data from file reference if given', async () => {
+			mock({
+				'/etc': {},
+				'/testdata': { 'a.conf': 'FIRST FILE', 'b.conf': 'SECOND FILE' },
+			});
+
+			await replace(
+				{
+					'/service-a': { 'a.conf': fileRef('/testdata/a.conf') },
+					'/service-b': { 'subdir/b.conf': fileRef('/testdata/b.conf') },
+				},
+				'/etc',
+			);
+
+			expect(await fs.readFile('/etc/service-a/a.conf', 'utf8')).to.equal(
+				'FIRST FILE',
+			);
+			expect(
+				await fs.readFile('/etc/service-b/subdir/b.conf', 'utf8'),
+			).to.equal('SECOND FILE');
+
+			mock.restore();
+		});
+
+		it('sets atime if provided in the file spec', async () => {
+			const atime = new Date('2022-08-16T17:00:00Z');
+			mock({
+				'/etc': {},
+				'/testdata': { 'b.conf': 'SECOND FILE' },
+			});
+
+			await replace(
+				{
+					'/service-a': {
+						'a.conf': fileSpec({
+							contents: 'FIRST FILE',
+							atime,
+						}),
+					},
+					'/service-b': {
+						'subdir/b.conf': fileRef({
+							from: '/testdata/b.conf',
+							atime,
+						}),
+					},
+				},
+				'/etc',
+			);
+			const aStat = await fs.stat('/etc/service-a/a.conf');
+			expect(aStat.atime).to.deep.equal(atime);
+			expect(await fs.readFile('/etc/service-a/a.conf', 'utf8')).to.equal(
+				'FIRST FILE',
+			);
+
+			const bStat = await fs.stat('/etc/service-b/subdir/b.conf');
+			expect(bStat.atime).to.deep.equal(atime);
+			expect(
+				await fs.readFile('/etc/service-b/subdir/b.conf', 'utf8'),
+			).to.equal('SECOND FILE');
+
+			mock.restore();
+		});
+
+		it('sets mtime if provided in the file spec', async () => {
+			const mtime = new Date('2022-08-16T17:00:00Z');
+			mock({
+				'/etc': {},
+				'/testdata': { 'b.conf': 'SECOND FILE' },
+			});
+
+			await replace(
+				{
+					'/service-a': {
+						'a.conf': fileSpec({
+							contents: 'FIRST FILE',
+							mtime,
+						}),
+					},
+					'/service-b': {
+						'subdir/b.conf': fileRef({
+							from: '/testdata/b.conf',
+							mtime,
+						}),
+					},
+				},
+				'/etc',
+			);
+			expect(await fs.readFile('/etc/service-a/a.conf', 'utf8')).to.equal(
+				'FIRST FILE',
+			);
+			const aStat = await fs.stat('/etc/service-a/a.conf');
+			expect(aStat.mtime).to.deep.equal(mtime);
+
+			expect(
+				await fs.readFile('/etc/service-b/subdir/b.conf', 'utf8'),
+			).to.equal('SECOND FILE');
+			const bStat = await fs.stat('/etc/service-b/subdir/b.conf');
+			expect(bStat.mtime).to.deep.equal(mtime);
 
 			mock.restore();
 		});

--- a/lib/testfs/utils.ts
+++ b/lib/testfs/utils.ts
@@ -209,11 +209,12 @@ export function fileSpec(
  */
 export function fileRef(
 	f: string | WithOptional<FileRef, keyof FileOpts>,
+	basedir = process.cwd(),
 ): FileRef {
 	const now = new Date();
 	if (isString(f)) {
 		if (!path.isAbsolute(f)) {
-			f = path.resolve(process.cwd(), f);
+			f = path.resolve(basedir, f);
 		}
 		return { from: f, mtime: now, atime: now };
 	}

--- a/lib/testfs/utils.ts
+++ b/lib/testfs/utils.ts
@@ -1,14 +1,44 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 
-import { Directory, File } from './types';
+import {
+	Directory,
+	File,
+	FileRef,
+	FileContents,
+	FileSpec,
+	FileOpts,
+	WithOptional,
+} from './types';
+
+const isString = (x: unknown): x is string =>
+	x != null && (typeof x === 'string' || x instanceof String);
+
+/**
+ * Type guard to check if object is a file contents
+ */
+export const isFileContents = (x: unknown): x is FileContents =>
+	x != null && (isString(x) || Buffer.isBuffer(x));
+
+/**
+ * Type guard to check if a object is a file reference
+ */
+export const isFileRef = (x: unknown): x is FileRef =>
+	x != null && typeof x === 'object' && isString((x as { from: any }).from);
+
+/**
+ * Type guard to check if an object is a file specification
+ */
+export const isFileSpec = (x: unknown): x is FileSpec =>
+	x != null &&
+	typeof x === 'object' &&
+	isFileContents((x as { contents: any }).contents);
 
 /**
  * Type guard to idenfity an object as a file
  */
 export const isFile = (x: unknown): x is File =>
-	x != null &&
-	(typeof x === 'string' || x instanceof String || Buffer.isBuffer(x));
+	(x != null && isFileContents(x)) || isFileRef(x) || isFileSpec(x);
 
 /**
  * Type guard to identify an object as a directory
@@ -148,7 +178,7 @@ export function dir(root: Directory): Directory {
  * Get all directories at the top level of the given
  * directory spec
  */
-export function dirs(root: Directory): string[] {
+export function dirNames(root: Directory): string[] {
 	return Object.keys(root).filter((file) => isDirectory(root[file]));
 }
 
@@ -156,8 +186,39 @@ export function dirs(root: Directory): string[] {
  * Get all files at the top level of the given
  * directory spec
  */
-export function files(root: Directory): string[] {
+export function fileNames(root: Directory): string[] {
 	return Object.keys(root).filter((file) => isFile(root[file]));
+}
+
+/**
+ * Create a file specification from a partial spec
+ */
+export function fileSpec(
+	f: string | Buffer | WithOptional<FileSpec, keyof FileOpts>,
+): FileSpec {
+	const now = new Date();
+	if (isFileContents(f)) {
+		return { contents: f, atime: now, mtime: now };
+	}
+
+	return { mtime: now, atime: now, ...f };
+}
+
+/**
+ * Create a file specification from a partial ref
+ */
+export function fileRef(
+	f: string | WithOptional<FileRef, keyof FileOpts>,
+): FileRef {
+	const now = new Date();
+	if (isString(f)) {
+		if (!path.isAbsolute(f)) {
+			f = path.resolve(process.cwd(), f);
+		}
+		return { from: f, mtime: now, atime: now };
+	}
+
+	return { mtime: now, atime: now, ...f };
 }
 
 /**
@@ -165,14 +226,14 @@ export function files(root: Directory): string[] {
  */
 function flatList(root: Directory, parent = '/'): Array<[string, File]> {
 	return (
-		files(root)
+		fileNames(root)
 			// Add top level files to the list
 			.map((file): [string, File] => [
 				path.resolve(parent, file),
 				root[file] as File,
 			])
 			.concat(
-				dirs(root)
+				dirNames(root)
 					// For each dir, calculate the list of files
 					.map((dirname) =>
 						flatList(root[dirname] as Directory, path.resolve(parent, dirname)),
@@ -238,8 +299,8 @@ export async function replace(spec: Directory, parent = '/') {
 	// Get the list of unique base directories for the given files
 	const uniqueDirs = [
 		...new Set(
-			files(spec)
-				.map((file) => path.dirname(file))
+			fileNames(spec)
+				.map((filename) => path.dirname(filename))
 				.filter((dirname) => dirname !== '.' && dirname !== '/')
 				.map((dirname) => dirname),
 		),
@@ -254,21 +315,41 @@ export async function replace(spec: Directory, parent = '/') {
 		),
 	);
 
+	// Get file contents from references if any
+	const filesWithSpec: Array<[string, FileSpec]> = await Promise.all(
+		fileNames(spec).map(async (filename) => {
+			const file = spec[filename];
+			if (isFileContents(file) || isFileSpec(file)) {
+				return [filename, fileSpec(file)];
+			}
+
+			const { from, ...opts } = fileRef(file as FileRef);
+			return fs
+				.readFile(from)
+				.then((contents) => [filename, { contents, ...opts }]);
+		}),
+	);
+
 	// Write all files first
 	// TODO: this writes in parallel, if necessary we might want to write
 	// in batches but maybe it won't be necessary given that this is for testing
 	await Promise.all(
-		files(spec).map((file) =>
+		filesWithSpec.map(([filename, filespec]) =>
 			fs
-				.open(path.join(parent, file), 'w')
-				.then((fd) =>
-					fd.writeFile(spec[file] as File).finally(() => fd.close()),
+				.open(path.join(parent, filename), 'w')
+				.then((fd) => fd.writeFile(filespec.contents).finally(() => fd.close()))
+				.then(() =>
+					fs.utimes(
+						path.join(parent, filename),
+						filespec.atime,
+						filespec.mtime,
+					),
 				),
 		),
 	);
 
 	// Write child directories sequentially (depth-first)
-	for (const dirPath of dirs(spec)) {
+	for (const dirPath of dirNames(spec)) {
 		await replace(spec[dirPath] as Directory, path.join(parent, dirPath));
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,85 +1,87 @@
 {
-  "name": "mocha-pod",
-  "version": "0.2.2",
-  "description": "Mocha + Docker. Run integration tests in a docker container",
-  "homepage": "https://github.com/balena-io-modules/mocha-pod#readme",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
-  "exports": {
-    ".": "./build/index.js",
-    "./attach": "./build/attach/index.js"
-  },
-  "keywords": [
-    "balena",
-    "typescript",
-    "mocha",
-    "testing",
-    "integration"
-  ],
-  "author": "Balena Inc. <hello@balena.io>",
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/balena-io-modules/mocha-pod.git"
-  },
-  "bugs": {
-    "url": "https://github.com/balena-io-modules/mocha-pod/issues"
-  },
-  "files": [
-    "build/",
-    "CHANGELOG.md",
-    "README.md"
-  ],
-  "engines": {
-    "node": ">=12.0.0"
-  },
-  "scripts": {
-    "clean": "rimraf build",
-    "typedoc": "rimraf docs && typedoc",
-    "build": "npm run clean && tsc --project tsconfig.release.json",
-    "lint": "balena-lint --typescript lib tests",
-    "lint-fix": "balena-lint --typescript --fix lib tests",
-    "test:unit": "mocha -r ts-node/register -r tsconfig-paths/register --reporter spec lib/**/*.spec.ts",
-    "test:integration": "mocha -r ts-node/register -r tsconfig-paths/register -r lib/attach  --reporter spec tests/**/*.spec.ts",
-    "test:node": "npm run test:unit && npm run test:integration",
-    "test": "npm run build && npm run lint && npm run test:node",
-    "test:fast": "npm run build && npm run test:node",
-    "prepack": "npm run build"
-  },
-  "devDependencies": {
-    "@balena/lint": "^5.4.2",
-    "@types/chai": "^4.2.18",
-    "@types/chai-as-promised": "^7.1.4",
-    "@types/debug": "^4.1.7",
-    "@types/dockerode": "^3.3.9",
-    "@types/js-yaml": "^4.0.5",
-    "@types/mocha": "^9.1.1",
-    "@types/tar-fs": "^2.0.1",
-    "@types/tar-stream": "^2.2.2",
-    "balena-config-karma": "^3.0.0",
-    "chai": "^4.3.4",
-    "chai-as-promised": "^7.1.1",
-    "husky": "^4.2.5",
-    "lint-staged": "^11.0.0",
-    "mocha": "^10.0.0",
-    "rimraf": "^3.0.2",
-    "ts-node": "^10.9.1",
-    "tsconfig-paths": "^4.0.0",
-    "typedoc": "^0.23.10",
-    "typedoc-plugin-markdown": "^3.13.4",
-    "typescript": "^4.7.4"
-  },
-  "dependencies": {
-    "@balena/compose": "^2.1.0",
-    "@balena/dockerignore": "^1.0.2",
-    "debug": "^4.3.4",
-    "dockerode": "^3.3.2",
-    "fast-glob": "^3.2.11",
-    "js-yaml": "^4.1.0",
-    "nanoid": "^3.3.4",
-    "tar-fs": "^2.1.1"
-  },
-  "versionist": {
-    "publishedAt": "2022-08-13T14:23:09.199Z"
-  }
+	"name": "mocha-pod",
+	"version": "0.2.2",
+	"description": "Mocha + Docker. Run integration tests in a docker container",
+	"homepage": "https://github.com/balena-io-modules/mocha-pod#readme",
+	"main": "build/index.js",
+	"types": "build/index.d.ts",
+	"exports": {
+		".": "./build/index.js",
+		"./attach": "./build/attach/index.js"
+	},
+	"keywords": [
+		"balena",
+		"typescript",
+		"mocha",
+		"testing",
+		"integration"
+	],
+	"author": "Balena Inc. <hello@balena.io>",
+	"license": "Apache-2.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/balena-io-modules/mocha-pod.git"
+	},
+	"bugs": {
+		"url": "https://github.com/balena-io-modules/mocha-pod/issues"
+	},
+	"files": [
+		"build/",
+		"CHANGELOG.md",
+		"README.md"
+	],
+	"engines": {
+		"node": ">=12.0.0"
+	},
+	"scripts": {
+		"clean": "rimraf build",
+		"typedoc": "rimraf docs && typedoc",
+		"build": "npm run clean && tsc --project tsconfig.release.json",
+		"lint": "balena-lint --typescript lib tests",
+		"lint-fix": "balena-lint --typescript --fix lib tests",
+		"test:unit": "mocha -r ts-node/register -r tsconfig-paths/register --reporter spec lib/**/*.spec.ts",
+		"test:integration": "mocha -r ts-node/register -r tsconfig-paths/register -r lib/attach  --reporter spec tests/**/*.spec.ts",
+		"test:node": "npm run test:unit && npm run test:integration",
+		"test": "npm run build && npm run lint && npm run test:node",
+		"test:fast": "npm run build && npm run test:node",
+		"prepack": "npm run build"
+	},
+	"devDependencies": {
+		"@balena/lint": "^5.4.2",
+		"@types/chai": "^4.2.18",
+		"@types/chai-as-promised": "^7.1.4",
+		"@types/debug": "^4.1.7",
+		"@types/dockerode": "^3.3.9",
+		"@types/js-yaml": "^4.0.5",
+		"@types/mocha": "^9.1.1",
+		"@types/mock-fs": "^4.13.1",
+		"@types/tar-fs": "^2.0.1",
+		"@types/tar-stream": "^2.2.2",
+		"balena-config-karma": "^3.0.0",
+		"chai": "^4.3.4",
+		"chai-as-promised": "^7.1.1",
+		"husky": "^4.2.5",
+		"lint-staged": "^11.0.0",
+		"mocha": "^10.0.0",
+		"mock-fs": "^5.1.4",
+		"rimraf": "^3.0.2",
+		"ts-node": "^10.9.1",
+		"tsconfig-paths": "^4.0.0",
+		"typedoc": "^0.23.10",
+		"typedoc-plugin-markdown": "^3.13.4",
+		"typescript": "^4.7.4"
+	},
+	"dependencies": {
+		"@balena/compose": "^2.1.0",
+		"@balena/dockerignore": "^1.0.2",
+		"debug": "^4.3.4",
+		"dockerode": "^3.3.2",
+		"fast-glob": "^3.2.11",
+		"js-yaml": "^4.1.0",
+		"nanoid": "^3.3.4",
+		"tar-fs": "^2.1.1"
+	},
+	"versionist": {
+		"publishedAt": "2022-08-13T14:23:09.199Z"
+	}
 }

--- a/tests/data/dummy.conf
+++ b/tests/data/dummy.conf
@@ -1,0 +1,1 @@
+loglevel=debug

--- a/tests/data/extra.conf
+++ b/tests/data/extra.conf
@@ -1,0 +1,1 @@
+debug=false

--- a/tests/hooks.spec.ts
+++ b/tests/hooks.spec.ts
@@ -18,6 +18,10 @@ describe('hooks: integration tests', function () {
 			fs.access('/etc/unused.conf'),
 			'global testfs files should not exist before testfs.setup()',
 		).to.be.rejected;
+		await expect(
+			fs.access('/etc/extra.conf'),
+			'global testfs files should not exist before testfs.setup()',
+		).to.be.rejected;
 
 		const tmp = await testfs().enable();
 
@@ -25,12 +29,19 @@ describe('hooks: integration tests', function () {
 		expect(await fs.readFile('/etc/unused.conf', 'utf-8')).to.equal(
 			'just for testing',
 		);
+		expect(await fs.readFile('/etc/extra.conf', 'utf-8')).to.equal(
+			await fs.readFile('tests/data/extra.conf', 'utf-8'),
+		);
 
 		await tmp.restore();
 
 		await expect(
 			fs.access('/etc/unused.conf'),
 			'global testfs files should not exist after testfs.restore()',
+		).to.be.rejected;
+		await expect(
+			fs.access('/etc/extra.conf'),
+			'global testfs files should not exist before testfs.setup()',
 		).to.be.rejected;
 	});
 });


### PR DESCRIPTION
This PR adds the capability to set the target files last access time (atime), last modification time (mtime), as well providing a way to create files referencing contents under a test data directory. For example

```typescritp
const tmp = await testfs({
	// Create a file reference
	'/etc/other.conf': testfs.from('tests/data/other.conf'),
}).enable();
```

Will setup a file `/etc/other.conf` with the contents from the file under `tests/data/other.conf`

Change-type: minor