### PR TITLE
Automatically detect deviceArch from uname

### DIFF
--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L65)
+[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L65)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L89)
+[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L89)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:119](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L119)
+[testfs/types.ts:119](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L119)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L80)
+[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L80)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L72)
+[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L72)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -32,4 +32,4 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:134](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L134)
+[testfs/types.ts:134](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L134)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -28,7 +28,7 @@ Location of the backup file
 
 #### Defined in
 
-[testfs/types.ts:101](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L101)
+[testfs/types.ts:101](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L101)
 
 ## Methods
 
@@ -48,4 +48,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:110](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L110)
+[testfs/types.ts:110](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L110)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -35,7 +35,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L21)
 
 ___
 
@@ -51,4 +51,4 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L28)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -39,7 +39,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:47](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L47)
+[testfs/types.ts:47](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L47)
 
 ___
 
@@ -72,4 +72,4 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L28)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -38,7 +38,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L21)
 
 ___
 
@@ -50,7 +50,7 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L35)
 
 ___
 
@@ -70,4 +70,4 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L28)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L65)
+[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L65)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L89)
+[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L89)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L80)
+[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L80)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L72)
+[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L72)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L154)
+[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L154)
 
 ## Table of contents
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:161](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L161)
+[testfs/types.ts:161](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L161)
 
 ___
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:186](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L186)
+[testfs/types.ts:186](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L186)
 
 ___
 
@@ -111,7 +111,7 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:195](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L195)
+[testfs/types.ts:195](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L195)
 
 ___
 
@@ -131,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:178](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L178)
+[testfs/types.ts:178](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L178)
 
 ___
 
@@ -150,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:169](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L169)
+[testfs/types.ts:169](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L169)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L154)
+[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L154)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -38,8 +38,8 @@ Renames and re-exports [Config](MochaPod.md#config)
 | :------ | :------ | :------ |
 | `basedir` | `string` | Base directory where configuration files are looked for. If a relative path is used, it is asumed to be relative to `process.cwd()`.  **`Default Value`**  `process.cwd()` |
 | `buildOnly` | `boolean` | Only perform the build step during the global mocha setup. If set to false this will run `npm run test` inside a container after the build.  **`Default Value`**  `false` |
-| `deviceArch` | ``"amd64"`` \| ``"aarch64"`` \| ``"armv7hf"`` \| ``"i386"`` \| ``"rpi"`` | The architecture of the system where the images will be built and ran.  **`Default Value`**  `amd64` |
-| `deviceType` | `string` | Device type. Used for replacing `%%BALENA_MACHINE_NAME%%` in Dockerfile.template if given.  It is inferred from the deviceArch if none are set. |
+| `deviceArch` | `string` | The architecture of the system where the images will be built and ran. This is used to replace `%%BALENA_ARCH%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works)  The architecture is detected automatically using `uname`, set this value if building on a device other than the local machine.  Supported values: `'amd64' \| 'aarch64' \| 'armv7hf' \| 'i386' \| 'rpi'`  **`Default Value`**  inferred from `process.arch` |
+| `deviceType` | `string` | The device type of the system where the images will be built an ran. This is used to replace `%%BALENA_MACHINE_NAME%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works) given.  The device type is inferred automatically from the device architecture, set this value if building on a device other than the local machine. |
 | `dockerBuildOpts` | { `[key: string]`: `any`;  } | Extra options to pass to the image build. See https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageBuild  **`Default Value`**  `{}` |
 | `dockerHost` | `string` | IP address or URL for the docker host. If no protocol is included, the protocol is assumed to be `tcp://` e.g. - `tcp://192.168.1.105` - `unix:///var/run/docker.sock`  **`Default Value`**  `unix:///var/run/docker.sock` |
 | `dockerIgnore` | `string`[] | List of default dockerignore directives. These are overriden if a `.dockerignore` file is defined at the project root.  NOTE: `*/*//.git` is always ignored  **`Default Value`**  `['!*/*//Dockerfile', '!*/*//Dockerfile.*/', '*/*//node_modules', '*/*//build', '*/*//coverage' ]` |
@@ -50,9 +50,9 @@ Renames and re-exports [Config](MochaPod.md#config)
 
 #### Defined in
 
-[config.ts:174](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/config.ts#L174)
+[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/config.ts#L215)
 
-[config.ts:8](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/config.ts#L8)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/config.ts#L13)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:174](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/config.ts#L174)
+[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/config.ts#L215)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:50](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L50)
+[testfs/types.ts:50](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L50)
 
 ___
 
@@ -52,7 +52,7 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L10)
 
 ___
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/c330bc8/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L4)

--- a/tests/hooks.spec.ts
+++ b/tests/hooks.spec.ts
@@ -2,10 +2,6 @@ import { testfs, MochaPod } from '~/mocha-pod';
 import { promises as fs } from 'fs';
 
 import { expect } from './chai';
-import { exec as execSync } from 'child_process';
-import { promisify } from 'util';
-
-export const exec = promisify(execSync);
 
 describe('hooks: integration tests', function () {
 	it('global testfs configuration should be used', async () => {

--- a/tests/testfs.spec.ts
+++ b/tests/testfs.spec.ts
@@ -6,7 +6,7 @@ import { expect } from './chai';
 import { exec as execSync } from 'child_process';
 import { promisify } from 'util';
 
-export const exec = promisify(execSync);
+const exec = promisify(execSync);
 
 describe('testfs: integration tests', function () {
 	it('setup should backup any files modified by the given directory spec', async () => {


### PR DESCRIPTION
Automatically detect deviceArch from uname

This makes the `deviceArch` setting in config only necessary if building
for a target architecture different than the one from the local machine.

Change-type: patch