### PR TITLE
Ensure build cache gets written to disk

### DIFF
--- a/lib/attach/fixtures.ts
+++ b/lib/attach/fixtures.ts
@@ -182,7 +182,7 @@ export async function mochaGlobalSetup() {
 	});
 
 	// Write the cache
-	writeCache(stageIds, cachePath);
+	await writeCache(stageIds, cachePath);
 
 	// If build only is set, we assume that the tests were ran within
 	// the image build and exit successfully. In that scenarion, if the tests failed, the build


### PR DESCRIPTION
Fixes missing `await` preventing the cache from getting written.

Change-type: patch