### PR TITLE
Add support for setting gid/uid on testfs

### DIFF
--- a/.mochapodrc.yml
+++ b/.mochapodrc.yml
@@ -14,6 +14,10 @@ dockerHost: unix:///var/run/docker.sock
 # Defaults to `false`
 buildOnly: true
 
+# Additional options to pass to the image build
+dockerBuildOpts:
+  target: 'testing' # this is the stage that runs integration tests
+
 # This defines default configuration that
 # should apply to all testfs instances
 testfs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine as build
+FROM node:16-alpine as build
 
 WORKDIR /usr/src/app
 
@@ -29,4 +29,9 @@ FROM build as testing
 # container instead of during the image build step.
 # Make sure you also have set the  `buildOnly` to `false` inside
 # .mochapodrc.yml
-RUN MOCHAPOD_SKIP_SETUP=1 npm run test
+RUN MOCHAPOD_SKIP_SETUP=1 npm run test:integration
+
+# Test everything else for the CI tests
+FROM testing as ci
+
+RUN npm run test:unit && npm run build && npm run lint

--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L65)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L79)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L89)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L103)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:119](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L119)
+[testfs/types.ts:133](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L133)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L80)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L94)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L72)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -32,4 +32,4 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:134](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L134)
+[testfs/types.ts:148](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L148)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -28,7 +28,7 @@ Location of the backup file
 
 #### Defined in
 
-[testfs/types.ts:101](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L101)
+[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L115)
 
 ## Methods
 
@@ -48,4 +48,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:110](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L110)
+[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L124)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -19,7 +19,9 @@ Generic file options
 ### Properties
 
 - [atime](TestFs.FileOpts.md#atime)
+- [gid](TestFs.FileOpts.md#gid)
 - [mtime](TestFs.FileOpts.md#mtime)
+- [uid](TestFs.FileOpts.md#uid)
 
 ## Properties
 
@@ -35,7 +37,23 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L21)
+
+___
+
+### <a id="gid" name="gid"></a> gid
+
+• **gid**: `number`
+
+Group id for the file
+
+**`Default Value`**
+
+`process.getgid()`
+
+#### Defined in
+
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L42)
 
 ___
 
@@ -51,4 +69,18 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L28)
+
+___
+
+### <a id="uid" name="uid"></a> uid
+
+• **uid**: `number`
+
+User id for the file
+
+@defaultValue: `process.getuid()`
+
+#### Defined in
+
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -19,7 +19,9 @@ be loaded from an existing file in the filesystem
 
 - [atime](TestFs.FileRef.md#atime)
 - [from](TestFs.FileRef.md#from)
+- [gid](TestFs.FileRef.md#gid)
 - [mtime](TestFs.FileRef.md#mtime)
+- [uid](TestFs.FileRef.md#uid)
 
 ## Properties
 
@@ -39,7 +41,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +54,27 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:47](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L47)
+[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L61)
+
+___
+
+### <a id="gid" name="gid"></a> gid
+
+• **gid**: `number`
+
+Group id for the file
+
+**`Default Value`**
+
+`process.getgid()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[gid](TestFs.FileOpts.md#gid)
+
+#### Defined in
+
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L42)
 
 ___
 
@@ -72,4 +94,22 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L28)
+
+___
+
+### <a id="uid" name="uid"></a> uid
+
+• **uid**: `number`
+
+User id for the file
+
+@defaultValue: `process.getuid()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[uid](TestFs.FileOpts.md#uid)
+
+#### Defined in
+
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -18,7 +18,9 @@ Generic file options
 
 - [atime](TestFs.FileSpec.md#atime)
 - [contents](TestFs.FileSpec.md#contents)
+- [gid](TestFs.FileSpec.md#gid)
 - [mtime](TestFs.FileSpec.md#mtime)
+- [uid](TestFs.FileSpec.md#uid)
 
 ## Properties
 
@@ -38,7 +40,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L21)
 
 ___
 
@@ -50,7 +52,27 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L35)
+[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L49)
+
+___
+
+### <a id="gid" name="gid"></a> gid
+
+• **gid**: `number`
+
+Group id for the file
+
+**`Default Value`**
+
+`process.getgid()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[gid](TestFs.FileOpts.md#gid)
+
+#### Defined in
+
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L42)
 
 ___
 
@@ -70,4 +92,22 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L28)
+
+___
+
+### <a id="uid" name="uid"></a> uid
+
+• **uid**: `number`
+
+User id for the file
+
+@defaultValue: `process.getuid()`
+
+#### Inherited from
+
+[FileOpts](TestFs.FileOpts.md).[uid](TestFs.FileOpts.md#uid)
+
+#### Defined in
+
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:65](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L65)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L79)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:89](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L89)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:80](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L80)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L94)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:72](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L72)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L154)
+[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L168)
 
 ## Table of contents
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:161](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L161)
+[testfs/types.ts:175](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L175)
 
 ___
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:186](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L186)
+[testfs/types.ts:200](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L200)
 
 ___
 
@@ -111,7 +111,7 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:195](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L195)
+[testfs/types.ts:209](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L209)
 
 ___
 
@@ -131,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:178](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L178)
+[testfs/types.ts:192](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L192)
 
 ___
 
@@ -150,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:169](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L169)
+[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L183)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L154)
+[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L168)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -50,9 +50,9 @@ Renames and re-exports [Config](MochaPod.md#config)
 
 #### Defined in
 
-[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/config.ts#L215)
+[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/config.ts#L215)
 
-[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/config.ts#L13)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/config.ts#L13)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/config.ts#L215)
+[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/config.ts#L215)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:50](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L50)
+[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L64)
 
 ___
 
@@ -52,7 +52,7 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L10)
 
 ___
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/f3a69be/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L4)

--- a/lib/testfs/types.ts
+++ b/lib/testfs/types.ts
@@ -26,6 +26,20 @@ export interface FileOpts {
 	 * @defaultValue `new Date()`
 	 */
 	mtime: Date;
+
+	/**
+	 * User id for the file
+	 *
+	 * @defaultValue: `process.getuid()`
+	 */
+	uid: number;
+
+	/**
+	 * Group id for the file
+	 *
+	 * @defaultValue `process.getgid()`
+	 */
+	gid: number;
 }
 
 export interface FileSpec extends FileOpts {

--- a/lib/testfs/utils.spec.ts
+++ b/lib/testfs/utils.spec.ts
@@ -364,5 +364,83 @@ describe('testfs/utils: unit tests', function () {
 
 			mock.restore();
 		});
+
+		it('sets uid if provided in the file spec', async () => {
+			const uid = 65534;
+			mock({
+				'/etc': {},
+				'/testdata': { 'b.conf': 'SECOND FILE' },
+			});
+
+			await replace(
+				{
+					'/service-a': {
+						'a.conf': fileSpec({
+							contents: 'FIRST FILE',
+							uid,
+						}),
+					},
+					'/service-b': {
+						'subdir/b.conf': fileRef({
+							from: '/testdata/b.conf',
+							uid,
+						}),
+					},
+				},
+				'/etc',
+			);
+			expect(await fs.readFile('/etc/service-a/a.conf', 'utf8')).to.equal(
+				'FIRST FILE',
+			);
+			const aStat = await fs.stat('/etc/service-a/a.conf');
+			expect(aStat.uid).to.deep.equal(uid);
+
+			expect(
+				await fs.readFile('/etc/service-b/subdir/b.conf', 'utf8'),
+			).to.equal('SECOND FILE');
+			const bStat = await fs.stat('/etc/service-b/subdir/b.conf');
+			expect(bStat.uid).to.deep.equal(uid);
+
+			mock.restore();
+		});
+
+		it('sets gid if provided in the file spec', async () => {
+			const gid = 65534;
+			mock({
+				'/etc': {},
+				'/testdata': { 'b.conf': 'SECOND FILE' },
+			});
+
+			await replace(
+				{
+					'/service-a': {
+						'a.conf': fileSpec({
+							contents: 'FIRST FILE',
+							gid,
+						}),
+					},
+					'/service-b': {
+						'subdir/b.conf': fileRef({
+							from: '/testdata/b.conf',
+							gid,
+						}),
+					},
+				},
+				'/etc',
+			);
+			expect(await fs.readFile('/etc/service-a/a.conf', 'utf8')).to.equal(
+				'FIRST FILE',
+			);
+			const aStat = await fs.stat('/etc/service-a/a.conf');
+			expect(aStat.gid).to.deep.equal(gid);
+
+			expect(
+				await fs.readFile('/etc/service-b/subdir/b.conf', 'utf8'),
+			).to.equal('SECOND FILE');
+			const bStat = await fs.stat('/etc/service-b/subdir/b.conf');
+			expect(bStat.gid).to.deep.equal(gid);
+
+			mock.restore();
+		});
 	});
 });

--- a/tests/testfs.spec.ts
+++ b/tests/testfs.spec.ts
@@ -328,4 +328,60 @@ describe('testfs: integration tests', function () {
 			'file should not exist after the test',
 		).to.be.rejected;
 	});
+
+	it('setup should allow to configure file uid through the directory spec', async () => {
+		// The file should not exist before the test
+		await expect(
+			fs.access('/etc/other.conf'),
+			'file should not exist before the test',
+		).to.be.rejected;
+
+		// Prepare a new test fs
+		const uid = 65534;
+		const tmp = await testfs({
+			// Create a file with a set atime
+			'/etc/other.conf': testfs.file({ contents: 'loglevel=debug', uid }),
+		}).enable();
+
+		// The file should be available after setup and have the proper time
+		const fStat = await fs.stat('/etc/other.conf');
+		expect(fStat.uid).to.deep.equal(uid);
+
+		// Restore the filesystem
+		await tmp.restore();
+
+		// The file should have been removed
+		await expect(
+			fs.access('/etc/other.conf'),
+			'file should not exist after the test',
+		).to.be.rejected;
+	});
+
+	it('setup should allow to configure file uid through the directory spec', async () => {
+		// The file should not exist before the test
+		await expect(
+			fs.access('/etc/other.conf'),
+			'file should not exist before the test',
+		).to.be.rejected;
+
+		// Prepare a new test fs
+		const gid = 65534;
+		const tmp = await testfs({
+			// Create a file with a set atime
+			'/etc/other.conf': testfs.file({ contents: 'loglevel=debug', gid }),
+		}).enable();
+
+		// The file should be available after setup and have the proper time
+		const fStat = await fs.stat('/etc/other.conf');
+		expect(fStat.gid).to.deep.equal(gid);
+
+		// Restore the filesystem
+		await tmp.restore();
+
+		// The file should have been removed
+		await expect(
+			fs.access('/etc/other.conf'),
+			'file should not exist after the test',
+		).to.be.rejected;
+	});
 });


### PR DESCRIPTION
This allows to configure the target uid and gid when setting up the filesystem.
This PR also includes some small changes to the dockerfile to improve development speed.

Change-type: minor