### PR TITLE
Allow to create empty files using testfs.file()

### DIFF
--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L79)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L103)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:133](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L133)
+[testfs/types.ts:133](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L133)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L94)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -32,4 +32,4 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:148](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L148)
+[testfs/types.ts:148](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L148)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -28,7 +28,7 @@ Location of the backup file
 
 #### Defined in
 
-[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L115)
+[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L115)
 
 ## Methods
 
@@ -48,4 +48,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L124)
+[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L124)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -37,7 +37,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L21)
 
 ___
 
@@ -53,7 +53,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L42)
 
 ___
 
@@ -69,7 +69,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L28)
 
 ___
 
@@ -83,4 +83,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -41,7 +41,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L61)
+[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L61)
 
 ___
 
@@ -74,7 +74,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L42)
 
 ___
 
@@ -94,7 +94,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L28)
 
 ___
 
@@ -112,4 +112,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -40,7 +40,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L49)
+[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L49)
 
 ___
 
@@ -72,7 +72,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L42)
 
 ___
 
@@ -92,7 +92,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L79)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L94)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L168)
+[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L168)
 
 ## Table of contents
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:175](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L175)
+[testfs/types.ts:175](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L175)
 
 ___
 
@@ -77,7 +77,7 @@ Create a file specification from a partial file description
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `f` | `string` \| `Buffer` \| [`WithOptional`](../modules/TestFs.md#withoptional)<[`FileSpec`](TestFs.FileSpec.md), keyof [`FileOpts`](TestFs.FileOpts.md)\> | file contents or partial file specification |
+| `f` | `string` \| `Buffer` \| `Partial`<[`FileSpec`](TestFs.FileSpec.md)\> | file contents or partial file specification |
 
 #### Returns
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:200](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L200)
+[testfs/types.ts:200](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L200)
 
 ___
 
@@ -111,7 +111,7 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:209](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L209)
+[testfs/types.ts:209](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L209)
 
 ___
 
@@ -131,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:192](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L192)
+[testfs/types.ts:192](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L192)
 
 ___
 
@@ -150,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L183)
+[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L183)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L168)
+[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L168)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -50,9 +50,9 @@ Renames and re-exports [Config](MochaPod.md#config)
 
 #### Defined in
 
-[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/config.ts#L215)
+[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/config.ts#L215)
 
-[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/config.ts#L13)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/config.ts#L13)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/config.ts#L215)
+[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/config.ts#L215)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L64)
+[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L64)
 
 ___
 
@@ -52,7 +52,7 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L10)
 
 ___
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/01a67c2/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L4)

--- a/lib/testfs/types.ts
+++ b/lib/testfs/types.ts
@@ -197,7 +197,7 @@ export interface TestFs {
 	 * @param f - file contents or partial file specification
 	 * @return full file specification with defaults set
 	 */
-	file(f: string | Buffer | WithOptional<FileSpec, keyof FileOpts>): FileSpec;
+	file(f: string | Buffer | Partial<FileSpec>): FileSpec;
 
 	/**
 	 * Create a file reference to an existing file

--- a/lib/testfs/utils.ts
+++ b/lib/testfs/utils.ts
@@ -193,9 +193,7 @@ export function fileNames(root: Directory): string[] {
 /**
  * Create a file specification from a partial spec
  */
-export function fileSpec(
-	f: string | Buffer | WithOptional<FileSpec, keyof FileOpts>,
-): FileSpec {
+export function fileSpec(f: string | Buffer | Partial<FileSpec>): FileSpec {
 	const now = new Date();
 
 	// getuid and getgid are not available on Windows, this
@@ -206,7 +204,7 @@ export function fileSpec(
 		return { contents: f, atime: now, mtime: now, uid, gid };
 	}
 
-	return { mtime: now, atime: now, uid, gid, ...f };
+	return { contents: '', mtime: now, atime: now, uid, gid, ...f };
 }
 
 /**


### PR DESCRIPTION
This allows the `contents` property in the specification argument to
`testfs.file` to be optional. If not given, then an empty string will be
used as the file contents.

Change-type: patch