### PR TITLE
Allow to use DOCKER_HOST to override configuration

### DIFF
--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L79)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L103)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:133](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L133)
+[testfs/types.ts:133](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L133)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L94)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -32,4 +32,4 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:148](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L148)
+[testfs/types.ts:148](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L148)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -28,7 +28,7 @@ Location of the backup file
 
 #### Defined in
 
-[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L115)
+[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L115)
 
 ## Methods
 
@@ -48,4 +48,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L124)
+[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L124)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -37,7 +37,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L21)
 
 ___
 
@@ -53,7 +53,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L42)
 
 ___
 
@@ -69,7 +69,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L28)
 
 ___
 
@@ -83,4 +83,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -41,7 +41,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L61)
+[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L61)
 
 ___
 
@@ -74,7 +74,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L42)
 
 ___
 
@@ -94,7 +94,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L28)
 
 ___
 
@@ -112,4 +112,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -40,7 +40,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L49)
+[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L49)
 
 ___
 
@@ -72,7 +72,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L42)
 
 ___
 
@@ -92,7 +92,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L79)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L94)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L168)
+[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L168)
 
 ## Table of contents
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:175](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L175)
+[testfs/types.ts:175](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L175)
 
 ___
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:200](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L200)
+[testfs/types.ts:200](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L200)
 
 ___
 
@@ -111,7 +111,7 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:209](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L209)
+[testfs/types.ts:209](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L209)
 
 ___
 
@@ -131,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:192](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L192)
+[testfs/types.ts:192](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L192)
 
 ___
 
@@ -150,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L183)
+[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L183)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L168)
+[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L168)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -41,7 +41,7 @@ Renames and re-exports [Config](MochaPod.md#config)
 | `deviceArch` | `string` | The architecture of the system where the images will be built and ran. This is used to replace `%%BALENA_ARCH%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works)  The architecture is detected automatically using `uname`, set this value if building on a device other than the local machine.  Supported values: `'amd64' \| 'aarch64' \| 'armv7hf' \| 'i386' \| 'rpi'`  **`Default Value`**  inferred from `process.arch` |
 | `deviceType` | `string` | The device type of the system where the images will be built an ran. This is used to replace `%%BALENA_MACHINE_NAME%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works) given.  The device type is inferred automatically from the device architecture, set this value if building on a device other than the local machine. |
 | `dockerBuildOpts` | { `[key: string]`: `any`;  } | Extra options to pass to the image build. See https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageBuild  **`Default Value`**  `{}` |
-| `dockerHost` | `string` | IP address or URL for the docker host. If no protocol is included, the protocol is assumed to be `tcp://` e.g. - `tcp://192.168.1.105` - `unix:///var/run/docker.sock`  **`Default Value`**  `unix:///var/run/docker.sock` |
+| `dockerHost` | `string` | IP address or URL for the docker host. If no protocol is included, the protocol is assumed to be `tcp://` e.g. - `tcp://192.168.1.105` - `unix:///var/run/docker.sock`  The configuration value can be overriden by setting the `DOCKER_HOST` environment variable.  **`Default Value`**  `unix:///var/run/docker.sock` |
 | `dockerIgnore` | `string`[] | List of default dockerignore directives. These are overriden if a `.dockerignore` file is defined at the project root.  NOTE: `*/*//.git` is always ignored  **`Default Value`**  `['!*/*//Dockerfile', '!*/*//Dockerfile.*/', '*/*//node_modules', '*/*//build', '*/*//coverage' ]` |
 | `logging` | `string` | Log namespaces to enable. This can also be controlled via the `DEBUG` env var.  See https://github.com/debug-js/debug  **`Default Value`**  `'mocha-pod,mocha-pod:error'` |
 | `projectName` | `string` | Name of the project where mocha-pod is being ran on. By default it will get the name from `package.json` at `basedir`, if it does not exist, it will use `mocha-pod-testing` |
@@ -50,9 +50,9 @@ Renames and re-exports [Config](MochaPod.md#config)
 
 #### Defined in
 
-[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/config.ts#L215)
+[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/config.ts#L218)
 
-[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/config.ts#L13)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/config.ts#L13)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/config.ts#L215)
+[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/config.ts#L218)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L64)
+[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L64)
 
 ___
 
@@ -52,7 +52,7 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L10)
 
 ___
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/44a2ef1/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L4)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -43,6 +43,9 @@ export type Config = {
 	 * - `tcp://192.168.1.105`
 	 * - `unix:///var/run/docker.sock`
 	 *
+	 * The configuration value can be overriden by setting the `DOCKER_HOST` environment
+	 * variable.
+	 *
 	 * @defaultValue `unix:///var/run/docker.sock`
 	 */
 	dockerHost: string;
@@ -264,8 +267,11 @@ export async function Config(
 	// Infer the device type one more time if the user has changed it
 	const deviceType = inferDeviceTypeFormArch(conf.deviceArch);
 
+	// Allow overriding the configured docker host using an env var
+	const dockerHost = process.env.DOCKER_HOST ?? conf.dockerHost;
+
 	// Use absolute path for the basedir
-	return { ...conf, basedir: toAbsolute(conf.basedir), deviceType };
+	return { ...conf, basedir: toAbsolute(conf.basedir), deviceType, dockerHost };
 }
 
 export default Config;


### PR DESCRIPTION
If the `DOCKER_HOST` environment variable is set, it will be used to
override the values defined in `.mochapodrc.yml`. This is to allow
mocha-pod projects to be used in different contexts without the need to
modify the configuration file for each context.

Change-type: minor