### PR TITLE
Allow multiple testfs instances to be set at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ On restore, the module will
 - delete any files in the cleanup list
 - restore the original filesystem files from the backup
 
-Note that attempts to call `enable()` more than once will cause an exception.
+Note that if setting multiple `testfs` instances, the instances need to be restored in the reverse order that they were set. This is enforced by the testfs module and it will cause an exception otherwise.
 
 **IMPORTANT** don't use this module in a real (non-containerized) system, specially with admin permissions, you risk leaving the system
 in an inconsistent state if a crash happens before a `restore()` can be performed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,7 +143,7 @@ On restore, the module will
 - delete any files in the cleanup list
 - restore the original filesystem files from the backup
 
-Note that attempts to call `enable()` more than once will cause an exception.
+Note that if setting multiple `testfs` instances, the instances need to be restored in the reverse order that they were set. This is enforced by the testfs module and it will cause an exception otherwise.
 
 **IMPORTANT** don't use this module in a real (non-containerized) system, specially with admin permissions, you risk leaving the system
 in an inconsistent state if a crash happens before a `restore()` can be performed.

--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L79)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L103)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:133](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L133)
+[testfs/types.ts:138](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L138)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L94)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -32,4 +32,4 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:148](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L148)
+[testfs/types.ts:153](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L153)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -13,6 +13,7 @@ When in this state, the only possible action is to
 ### Properties
 
 - [backup](TestFs.Enabled.md#backup)
+- [id](TestFs.Enabled.md#id)
 
 ### Methods
 
@@ -28,7 +29,19 @@ Location of the backup file
 
 #### Defined in
 
-[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L115)
+[testfs/types.ts:120](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L120)
+
+___
+
+### <a id="id" name="id"></a> id
+
+• `Readonly` **id**: `string`
+
+Id of the testfs instance
+
+#### Defined in
+
+[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L115)
 
 ## Methods
 
@@ -48,4 +61,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L124)
+[testfs/types.ts:129](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L129)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -37,7 +37,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L21)
 
 ___
 
@@ -53,7 +53,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L42)
 
 ___
 
@@ -69,7 +69,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L28)
 
 ___
 
@@ -83,4 +83,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -41,7 +41,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L61)
+[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L61)
 
 ___
 
@@ -74,7 +74,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L42)
 
 ___
 
@@ -94,7 +94,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L28)
 
 ___
 
@@ -112,4 +112,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -40,7 +40,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L49)
+[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L49)
 
 ___
 
@@ -72,7 +72,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L42)
 
 ___
 
@@ -92,7 +92,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L79)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L94)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L168)
+[testfs/types.ts:173](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L173)
 
 ## Table of contents
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:175](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L175)
+[testfs/types.ts:180](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L180)
 
 ___
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:200](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L200)
+[testfs/types.ts:205](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L205)
 
 ___
 
@@ -111,7 +111,7 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:209](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L209)
+[testfs/types.ts:214](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L214)
 
 ___
 
@@ -131,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:192](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L192)
+[testfs/types.ts:197](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L197)
 
 ___
 
@@ -150,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L183)
+[testfs/types.ts:188](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L188)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:168](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L168)
+[testfs/types.ts:173](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L173)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -46,13 +46,13 @@ Renames and re-exports [Config](MochaPod.md#config)
 | `logging` | `string` | Log namespaces to enable. This can also be controlled via the `DEBUG` env var.  See https://github.com/debug-js/debug  **`Default Value`**  `'mocha-pod,mocha-pod:error'` |
 | `projectName` | `string` | Name of the project where mocha-pod is being ran on. By default it will get the name from `package.json` at `basedir`, if it does not exist, it will use `mocha-pod-testing` |
 | `testCommand` | `string`[] | Test command to use when running tests within a container. This will only be used if `buildOnly` is set to `false`.  **`Default Value`**  `["npm", "run", "test"]` |
-| `testfs` | `Partial`<`Omit`<[`Config`](../interfaces/TestFs.Config.md), ``"basedir"``\>\> | TestFs configuration to be used globally for all tests.  **`Default Value`**  `{}` |
+| `testfs` | `Partial`<`Omit`<[`Config`](../interfaces/TestFs.Config.md), ``"basedir"``\>\> | TestFs configuration to be set by the `beforeAll` mocha-pod hook.  **`Default Value`**  `{}` |
 
 #### Defined in
 
-[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/config.ts#L218)
+[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/config.ts#L218)
 
-[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/config.ts#L13)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/config.ts#L13)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/config.ts#L218)
+[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/config.ts#L218)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L64)
+[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L64)
 
 ___
 
@@ -52,7 +52,7 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L10)
 
 ___
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/511c926/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L4)

--- a/lib/attach/hooks.ts
+++ b/lib/attach/hooks.ts
@@ -49,7 +49,18 @@ export const mochaHooks = {
 
 		// Read config and set testfs default configuration
 		const config = await Config();
-		testfs.config({ basedir: config.basedir, ...config.testfs });
+
+		const { filesystem, keep, cleanup, ...extra } = {
+			basedir: config.basedir,
+			...config.testfs,
+		};
+
+		// Setup a global instance before all tests
+		await testfs(filesystem, { keep, cleanup, ...extra }).enable();
+
+		// Use extra configurations in all tests
+		testfs.config(extra);
+
 		logger.debug('Using Config', JSON.stringify(config, null, 2));
 	},
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -109,7 +109,7 @@ export type Config = {
 	testCommand: string[];
 
 	/**
-	 * TestFs configuration to be used globally for all tests.
+	 * TestFs configuration to be set by the `beforeAll` mocha-pod hook.
 	 *
 	 * @defaultValue `{}`
 	 */

--- a/lib/testfs/types.ts
+++ b/lib/testfs/types.ts
@@ -110,6 +110,11 @@ export interface Opts {
  */
 export interface Enabled {
 	/**
+	 * Id of the testfs instance
+	 */
+	readonly id: string;
+
+	/**
 	 * Location of the backup file
 	 */
 	readonly backup: string;

--- a/package.json
+++ b/package.json
@@ -1,88 +1,89 @@
 {
-  "name": "mocha-pod",
-  "version": "0.6.0",
-  "description": "Mocha + Docker. Run integration tests in a docker container",
-  "homepage": "https://github.com/balena-io-modules/mocha-pod#readme",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
-  "exports": {
-    ".": "./build/index.js",
-    "./attach": "./build/attach/index.js",
-    "./skip-setup": "./build/attach/hooks.js"
-  },
-  "keywords": [
-    "balena",
-    "typescript",
-    "mocha",
-    "testing",
-    "integration"
-  ],
-  "author": "Balena Inc. <hello@balena.io>",
-  "license": "Apache-2.0",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/balena-io-modules/mocha-pod.git"
-  },
-  "bugs": {
-    "url": "https://github.com/balena-io-modules/mocha-pod/issues"
-  },
-  "files": [
-    "build/",
-    "CHANGELOG.md",
-    "README.md"
-  ],
-  "engines": {
-    "node": ">=12.0.0"
-  },
-  "scripts": {
-    "clean": "rimraf build",
-    "typedoc": "rimraf docs && typedoc",
-    "build": "npm run clean && tsc --project tsconfig.release.json",
-    "lint": "balena-lint --typescript lib tests",
-    "lint-fix": "balena-lint --typescript --fix lib tests",
-    "test:unit": "mocha -r ts-node/register -r tsconfig-paths/register --reporter spec lib/**/*.spec.ts",
-    "test:integration": "mocha -r ts-node/register -r tsconfig-paths/register -r lib/attach  --reporter spec tests/**/*.spec.ts",
-    "test:node": "npm run test:unit && npm run test:integration",
-    "test": "npm run build && npm run lint && npm run test:node",
-    "test:fast": "npm run build && npm run test:node",
-    "prepack": "npm run build"
-  },
-  "devDependencies": {
-    "@balena/lint": "^5.4.2",
-    "@types/chai": "^4.2.18",
-    "@types/chai-as-promised": "^7.1.4",
-    "@types/debug": "^4.1.7",
-    "@types/dockerode": "^3.3.9",
-    "@types/js-yaml": "^4.0.5",
-    "@types/mocha": "^9.1.1",
-    "@types/mock-fs": "^4.13.1",
-    "@types/tar-fs": "^2.0.1",
-    "@types/tar-stream": "^2.2.2",
-    "balena-config-karma": "^3.0.0",
-    "chai": "^4.3.4",
-    "chai-as-promised": "^7.1.1",
-    "husky": "^4.2.5",
-    "lint-staged": "^11.0.0",
-    "mocha": "^10.0.0",
-    "mock-fs": "^5.1.4",
-    "rimraf": "^3.0.2",
-    "ts-node": "^10.9.1",
-    "tsconfig-paths": "^4.0.0",
-    "typedoc": "^0.23.10",
-    "typedoc-plugin-markdown": "^3.13.4",
-    "typescript": "^4.7.4"
-  },
-  "dependencies": {
-    "@balena/compose": "^2.1.0",
-    "@balena/dockerignore": "^1.0.2",
-    "debug": "^4.3.4",
-    "dockerode": "^3.3.2",
-    "fast-glob": "^3.2.11",
-    "js-yaml": "^4.1.0",
-    "nanoid": "^3.3.4",
-    "tar-fs": "^2.1.1"
-  },
-  "versionist": {
-    "publishedAt": "2022-08-23T18:29:52.865Z"
-  }
+	"name": "mocha-pod",
+	"version": "0.6.0",
+	"description": "Mocha + Docker. Run integration tests in a docker container",
+	"homepage": "https://github.com/balena-io-modules/mocha-pod#readme",
+	"main": "build/index.js",
+	"types": "build/index.d.ts",
+	"exports": {
+		".": "./build/index.js",
+		"./attach": "./build/attach/index.js",
+		"./skip-setup": "./build/attach/hooks.js"
+	},
+	"keywords": [
+		"balena",
+		"typescript",
+		"mocha",
+		"testing",
+		"integration"
+	],
+	"author": "Balena Inc. <hello@balena.io>",
+	"license": "Apache-2.0",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/balena-io-modules/mocha-pod.git"
+	},
+	"bugs": {
+		"url": "https://github.com/balena-io-modules/mocha-pod/issues"
+	},
+	"files": [
+		"build/",
+		"CHANGELOG.md",
+		"README.md"
+	],
+	"engines": {
+		"node": ">=12.0.0"
+	},
+	"scripts": {
+		"clean": "rimraf build",
+		"typedoc": "rimraf docs && typedoc",
+		"build": "npm run clean && tsc --project tsconfig.release.json",
+		"lint": "balena-lint --typescript lib tests",
+		"lint-fix": "balena-lint --typescript --fix lib tests",
+		"test:unit": "mocha -r ts-node/register -r tsconfig-paths/register --reporter spec lib/**/*.spec.ts",
+		"test:integration": "mocha -r ts-node/register -r tsconfig-paths/register -r lib/attach --bail --reporter spec tests/**/*.spec.ts",
+		"test:node": "npm run test:unit && npm run test:integration",
+		"test": "npm run build && npm run lint && npm run test:node",
+		"test:fast": "npm run build && npm run test:node",
+		"prepack": "npm run build"
+	},
+	"devDependencies": {
+		"@balena/lint": "^5.4.2",
+		"@types/chai": "^4.2.18",
+		"@types/chai-as-promised": "^7.1.4",
+		"@types/debug": "^4.1.7",
+		"@types/dockerode": "^3.3.9",
+		"@types/js-yaml": "^4.0.5",
+		"@types/mocha": "^9.1.1",
+		"@types/mock-fs": "^4.13.1",
+		"@types/tar-fs": "^2.0.1",
+		"@types/tar-stream": "^2.2.2",
+		"balena-config-karma": "^3.0.0",
+		"chai": "^4.3.4",
+		"chai-as-promised": "^7.1.1",
+		"husky": "^4.2.5",
+		"lint-staged": "^11.0.0",
+		"mocha": "^10.0.0",
+		"mock-fs": "^5.1.4",
+		"rimraf": "^3.0.2",
+		"ts-node": "^10.9.1",
+		"tsconfig-paths": "^4.0.0",
+		"typedoc": "^0.23.10",
+		"typedoc-plugin-markdown": "^3.13.4",
+		"typescript": "^4.7.4"
+	},
+	"dependencies": {
+		"@balena/compose": "^2.1.0",
+		"@balena/dockerignore": "^1.0.2",
+		"better-lock": "^2.0.3",
+		"debug": "^4.3.4",
+		"dockerode": "^3.3.2",
+		"fast-glob": "^3.2.11",
+		"js-yaml": "^4.1.0",
+		"nanoid": "^3.3.4",
+		"tar-fs": "^2.1.1"
+	},
+	"versionist": {
+		"publishedAt": "2022-08-23T18:29:52.865Z"
+	}
 }

--- a/tests/hooks.spec.ts
+++ b/tests/hooks.spec.ts
@@ -12,19 +12,37 @@ describe('hooks: integration tests', function () {
 
 		await expect(
 			fs.access('/etc/unused.conf'),
-			'global testfs files should not exist before testfs.setup()',
-		).to.be.rejected;
+			'global testfs files should be set by the beforeAll hook',
+		).to.not.be.rejected;
 		await expect(
 			fs.access('/etc/extra.conf'),
-			'global testfs files should not exist before testfs.setup()',
-		).to.be.rejected;
-
-		const tmp = await testfs().enable();
+			'global testfs files should be set by the beforeAll hook',
+		).to.not.be.rejected;
 
 		// The file contents should match whatever is in config
 		expect(await fs.readFile('/etc/unused.conf', 'utf-8')).to.equal(
 			'just for testing',
 		);
+
+		await expect(
+			fs.access('/etc/other.conf'),
+			'local test files should not exist before `enable`',
+		).to.be.rejected;
+
+		const tmp = await testfs({
+			'/etc/other.conf': 'debug=1',
+			'/etc/unused.conf': 'something else',
+		}).enable();
+
+		// The new value needs to be set
+		expect(await fs.readFile('/etc/unused.conf', 'utf-8')).to.equal(
+			'something else',
+		);
+
+		// Additional files configured need to be given the new value
+		expect(await fs.readFile('/etc/other.conf', 'utf-8')).to.equal('debug=1');
+
+		// Files defined in config with `from` need to be loaded by the global hook
 		expect(await fs.readFile('/etc/extra.conf', 'utf-8')).to.equal(
 			await fs.readFile('tests/data/extra.conf', 'utf-8'),
 		);
@@ -32,12 +50,16 @@ describe('hooks: integration tests', function () {
 		await tmp.restore();
 
 		await expect(
-			fs.access('/etc/unused.conf'),
-			'global testfs files should not exist after testfs.restore()',
+			fs.access('/etc/other.conf'),
+			'local test files should not exist after `restore`',
 		).to.be.rejected;
+
+		expect(await fs.readFile('/etc/unused.conf', 'utf-8')).to.equal(
+			'just for testing',
+		);
 		await expect(
 			fs.access('/etc/extra.conf'),
-			'global testfs files should not exist before testfs.setup()',
-		).to.be.rejected;
+			'global testfs files are restored be set by global afterAll hook',
+		).to.not.be.rejected;
 	});
 });


### PR DESCRIPTION
In previous versions, only one testfs instance was allowed to be
set at the time. This was enforced by a global lock to prevent causing
filesystem inconsistencies if restoring the same set of files.

While this technically worked, it was too restrictive, as users may have
wanted to have a global testfs instance for all tests, while having
local testfs instances for specific tests.

With this new feature, multiple testfs instances are allowed as long as
they are restored in reverse order as they were set.

This is incorrect
```typescript
const fsOne = await testfs({'/etc/hostname': 'one'}).enable();
// This second call is allowed
const fsTwo = await testfs({'/etc/hostname': 'two'}).enable();
// Trying to restore in a different order will throw
await fsTwo.restore(); // this will throw!
```

This is correct
```typescript
const fsOne = await testfs({'/etc/hostname': 'one'}).enable();
// This second call is allowed
const fsTwo = await testfs({'/etc/hostname': 'two'}).enable();
// This will succeed
await fsOne.restore();
// The content of `/etc/hostname` is 'one' now
```

This PR also changes the behavior of the global `testfs` configuration in `.mochapodrc.yml`. The given configuration is now used to set a default instance in the `beforeAll` hook. This change is still minor as the outcome of running the tests is still the same.

Change-type: minor