### PR TITLE
Add `testfs.cleanup` function

### DIFF
--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L79)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L103)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:138](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L138)
+[testfs/types.ts:144](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L144)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L94)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -32,4 +32,4 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:153](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L153)
+[testfs/types.ts:159](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L159)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -17,6 +17,7 @@ When in this state, the only possible action is to
 
 ### Methods
 
+- [cleanup](TestFs.Enabled.md#cleanup)
 - [restore](TestFs.Enabled.md#restore)
 
 ## Properties
@@ -29,7 +30,7 @@ Location of the backup file
 
 #### Defined in
 
-[testfs/types.ts:120](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L120)
+[testfs/types.ts:120](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L120)
 
 ___
 
@@ -41,9 +42,26 @@ Id of the testfs instance
 
 #### Defined in
 
-[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L115)
+[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L115)
 
 ## Methods
+
+### <a id="cleanup" name="cleanup"></a> cleanup
+
+▸ **cleanup**(): `Promise`<[`Enabled`](TestFs.Enabled.md)\>
+
+Remove any files modified by the test as specified in the
+testfs `cleanup` configuration.
+
+#### Returns
+
+`Promise`<[`Enabled`](TestFs.Enabled.md)\>
+
+#### Defined in
+
+[testfs/types.ts:135](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L135)
+
+___
 
 ### <a id="restore" name="restore"></a> restore
 
@@ -61,4 +79,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:129](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L129)
+[testfs/types.ts:129](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L129)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -37,7 +37,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L21)
 
 ___
 
@@ -53,7 +53,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L42)
 
 ___
 
@@ -69,7 +69,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L28)
 
 ___
 
@@ -83,4 +83,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -41,7 +41,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L61)
+[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L61)
 
 ___
 
@@ -74,7 +74,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L42)
 
 ___
 
@@ -94,7 +94,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L28)
 
 ___
 
@@ -112,4 +112,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -40,7 +40,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L49)
+[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L49)
 
 ___
 
@@ -72,7 +72,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L42)
 
 ___
 
@@ -92,7 +92,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L79)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L94)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:173](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L173)
+[testfs/types.ts:179](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L179)
 
 ## Table of contents
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:180](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L180)
+[testfs/types.ts:186](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L186)
 
 ___
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:205](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L205)
+[testfs/types.ts:211](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L211)
 
 ___
 
@@ -111,7 +111,7 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:214](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L214)
+[testfs/types.ts:220](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L220)
 
 ___
 
@@ -131,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:197](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L197)
+[testfs/types.ts:203](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L203)
 
 ___
 
@@ -150,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:188](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L188)
+[testfs/types.ts:194](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L194)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:173](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L173)
+[testfs/types.ts:179](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L179)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -50,9 +50,9 @@ Renames and re-exports [Config](MochaPod.md#config)
 
 #### Defined in
 
-[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/config.ts#L218)
+[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/config.ts#L218)
 
-[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/config.ts#L13)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/config.ts#L13)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/config.ts#L218)
+[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/config.ts#L218)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L64)
+[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L64)
 
 ___
 
@@ -52,7 +52,7 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L10)
 
 ___
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/6ce4164/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L4)

--- a/lib/attach/fixtures.ts
+++ b/lib/attach/fixtures.ts
@@ -122,7 +122,10 @@ export async function mochaGlobalSetup() {
 
 	// Build the image ad get intermediate images from build.
 	// Necessary for multi stage caching
-	const { image, stageIds } = await new Promise((resolve) => {
+	const { image, stageIds } = await new Promise<{
+		image: string;
+		stageIds: string[];
+	}>((resolve) => {
 		// Store the stage ids for caching
 		const ids = [] as string[];
 

--- a/lib/attach/hooks.ts
+++ b/lib/attach/hooks.ts
@@ -49,6 +49,7 @@ export const mochaHooks = {
 
 		// Read config and set testfs default configuration
 		const config = await Config();
+		logger.debug('Using Config', JSON.stringify(config, null, 2));
 
 		const { filesystem, keep, cleanup, ...extra } = {
 			basedir: config.basedir,
@@ -60,8 +61,6 @@ export const mochaHooks = {
 
 		// Use extra configurations in all tests
 		testfs.config(extra);
-
-		logger.debug('Using Config', JSON.stringify(config, null, 2));
 	},
 
 	async afterAll() {

--- a/lib/testfs/types.ts
+++ b/lib/testfs/types.ts
@@ -127,6 +127,12 @@ export interface Enabled {
 	 * - restore the original filesystem files from the backup
 	 */
 	restore(): Promise<Disabled>;
+
+	/**
+	 * Remove any files modified by the test as specified in the
+	 * testfs `cleanup` configuration.
+	 */
+	cleanup(): Promise<Enabled>;
 }
 
 export interface Config extends Opts {


### PR DESCRIPTION
This allows to delete any files modified by the test as defined
in the `testfs` configuration.

This also adds some improvement to the testfs debug logs.

Change-type: minor