### PR TITLE
Fix nanoid version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "dockerode": "^3.3.2",
     "fast-glob": "^3.2.11",
     "js-yaml": "^4.1.0",
-    "nanoid": "^3.3.4",
+    "nanoid": "3.3.4",
     "tar-fs": "^2.1.1"
   },
   "versionist": {


### PR DESCRIPTION
Nanoid 4 and above is ESM only so this fixes the version to 3.x.x to avoid automated bumps by renovatebot.

Change-type: patch