### PR TITLE
Add build arguments to the docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:16-alpine as build
+ARG NODE_VERSION_MAJOR=16
+
+FROM node:${NODE_VERSION_MAJOR}-alpine as build
 
 WORKDIR /usr/src/app
 

--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L79)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L103)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:144](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L144)
+[testfs/types.ts:139](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L139)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L94)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -9,6 +9,7 @@
 ### Methods
 
 - [enable](TestFs.Disabled.md#enable)
+- [restore](TestFs.Disabled.md#restore)
 
 ## Methods
 
@@ -32,4 +33,24 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Defined in
 
-[testfs/types.ts:159](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L159)
+[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L154)
+
+___
+
+### <a id="restore" name="restore"></a> restore
+
+▸ **restore**(): `Promise`<[`Disabled`](TestFs.Disabled.md)\>
+
+If the instance has been enabled, restore the environment to the
+state before the filesystem was setup
+
+Nothing is done if the instance has not yet been enabled or it has alread
+been restored.
+
+#### Returns
+
+`Promise`<[`Disabled`](TestFs.Disabled.md)\>
+
+#### Defined in
+
+[testfs/types.ts:163](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L163)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -12,7 +12,6 @@ When in this state, the only possible action is to
 
 ### Properties
 
-- [backup](TestFs.Enabled.md#backup)
 - [id](TestFs.Enabled.md#id)
 
 ### Methods
@@ -22,18 +21,6 @@ When in this state, the only possible action is to
 
 ## Properties
 
-### <a id="backup" name="backup"></a> backup
-
-• `Readonly` **backup**: `string`
-
-Location of the backup file
-
-#### Defined in
-
-[testfs/types.ts:120](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L120)
-
-___
-
 ### <a id="id" name="id"></a> id
 
 • `Readonly` **id**: `string`
@@ -42,7 +29,7 @@ Id of the testfs instance
 
 #### Defined in
 
-[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L115)
+[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L115)
 
 ## Methods
 
@@ -59,7 +46,7 @@ testfs `cleanup` configuration.
 
 #### Defined in
 
-[testfs/types.ts:135](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L135)
+[testfs/types.ts:130](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L130)
 
 ___
 
@@ -79,4 +66,4 @@ The following operations are performed during restore
 
 #### Defined in
 
-[testfs/types.ts:129](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L129)
+[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L124)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -37,7 +37,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L21)
 
 ___
 
@@ -53,7 +53,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L42)
 
 ___
 
@@ -69,7 +69,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L28)
 
 ___
 
@@ -83,4 +83,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -41,7 +41,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L61)
+[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L61)
 
 ___
 
@@ -74,7 +74,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L42)
 
 ___
 
@@ -94,7 +94,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L28)
 
 ___
 
@@ -112,4 +112,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -40,7 +40,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L49)
+[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L49)
 
 ___
 
@@ -72,7 +72,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L42)
 
 ___
 
@@ -92,7 +92,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L79)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L94)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:179](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L179)
+[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L183)
 
 ## Table of contents
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:186](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L186)
+[testfs/types.ts:190](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L190)
 
 ___
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:211](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L211)
+[testfs/types.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L215)
 
 ___
 
@@ -111,7 +111,7 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:220](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L220)
+[testfs/types.ts:224](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L224)
 
 ___
 
@@ -131,7 +131,7 @@ safe to run the setup.
 
 #### Defined in
 
-[testfs/types.ts:203](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L203)
+[testfs/types.ts:207](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L207)
 
 ___
 
@@ -150,4 +150,4 @@ This function looks for a currently enabled instance of a test filesystem and ca
 
 #### Defined in
 
-[testfs/types.ts:194](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L194)
+[testfs/types.ts:198](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L198)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:179](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L179)
+[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L183)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -40,7 +40,7 @@ Renames and re-exports [Config](MochaPod.md#config)
 | `buildOnly` | `boolean` | Only perform the build step during the global mocha setup. If set to false this will run `npm run test` inside a container after the build.  **`Default Value`**  `false` |
 | `deviceArch` | `string` | The architecture of the system where the images will be built and ran. This is used to replace `%%BALENA_ARCH%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works)  The architecture is detected automatically using `uname`, set this value if building on a device other than the local machine.  Supported values: `'amd64' \| 'aarch64' \| 'armv7hf' \| 'i386' \| 'rpi'`  **`Default Value`**  inferred from `process.arch` |
 | `deviceType` | `string` | The device type of the system where the images will be built an ran. This is used to replace `%%BALENA_MACHINE_NAME%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works) given.  The device type is inferred automatically from the device architecture, set this value if building on a device other than the local machine. |
-| `dockerBuildOpts` | { `[key: string]`: `any`;  } | Extra options to pass to the image build. See https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageBuild  **`Default Value`**  `{}` |
+| `dockerBuildOpts` | { `[key: string]`: `any`;  } | Extra options to pass to the image build. See https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageBuild  **`Default Value`**  `{   buildArgs: {     NODE_VERSION // the host environment node version    NODE_VERSION_MAJOR // the host environment major node version    BALENA_ARCH // the host architecture or the configuration value set by the user    BALENA_MACHINE_NAME // the machine name as set by the user or inferred from the architecture   } }` |
 | `dockerHost` | `string` | IP address or URL for the docker host. If no protocol is included, the protocol is assumed to be `tcp://` e.g. - `tcp://192.168.1.105` - `unix:///var/run/docker.sock`  The configuration value can be overriden by setting the `DOCKER_HOST` environment variable.  **`Default Value`**  `unix:///var/run/docker.sock` |
 | `dockerIgnore` | `string`[] | List of default dockerignore directives. These are overriden if a `.dockerignore` file is defined at the project root.  NOTE: `*/*//.git` is always ignored  **`Default Value`**  `['!*/*//Dockerfile', '!*/*//Dockerfile.*/', '*/*//node_modules', '*/*//build', '*/*//coverage' ]` |
 | `logging` | `string` | Log namespaces to enable. This can also be controlled via the `DEBUG` env var.  See https://github.com/debug-js/debug  **`Default Value`**  `'mocha-pod,mocha-pod:error'` |
@@ -50,9 +50,9 @@ Renames and re-exports [Config](MochaPod.md#config)
 
 #### Defined in
 
-[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/config.ts#L218)
+[config.ts:225](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/config.ts#L225)
 
-[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/config.ts#L13)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/config.ts#L13)
 
 ## Functions
 
@@ -82,4 +82,4 @@ overrides the default values
 
 #### Defined in
 
-[config.ts:218](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/config.ts#L218)
+[config.ts:225](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/config.ts#L225)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L64)
+[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L64)
 
 ___
 
@@ -52,7 +52,7 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L10)
 
 ___
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/ee6b4c1/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L4)

--- a/lib/testfs/types.ts
+++ b/lib/testfs/types.ts
@@ -154,11 +154,11 @@ export interface Disabled {
 	enable(): Promise<Enabled>;
 
 	/**
-	 * Restore the environment to the state before the filesystem was setup
+	 * If the instance has been enabled, restore the environment to the
+	 * state before the filesystem was setup
 	 *
-	 * The following operations are performed during restore
-	 * - delete any files in the `cleanup` list
-	 * - restore the original filesystem files from the backup
+	 * Nothing is done if the instance has not yet been enabled or it has alread
+	 * been restored.
 	 */
 	restore(): Promise<Disabled>;
 }


### PR DESCRIPTION
This passes the following build arguments to the docker build

- NODE_VERSION: full Node version of the host
- NODE_MAJOR_VERSION: major Node version of the host
- BALENA_ARCH: infered balena arch from the host or configured by the user
- BALENA_MACHINE_NAME: infered balena machine name from the host or as configured by the user

This allows to better work with CI environments and modify the docker
build depending on the CI environment node version.

Change-type: minor