### PR TITLE
Update @balena/lint to v7

### DIFF
--- a/docs/interfaces/TestFs.Config.md
+++ b/docs/interfaces/TestFs.Config.md
@@ -26,7 +26,7 @@
 
 • `Readonly` **basedir**: `string`
 
-Directory to use as base for search when calling [from](TestFs.TestFs.md#from)
+Directory to use as base for search when calling [TestFs.from](TestFs.TestFs.md#from)
 
 **`Default Value`**
 
@@ -38,7 +38,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L79)
 
 ___
 
@@ -60,7 +60,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L103)
 
 ___
 
@@ -76,7 +76,7 @@ Additional directory specification to be passed to `testfs()`
 
 #### Defined in
 
-[testfs/types.ts:139](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L139)
+[testfs/types.ts:139](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L139)
 
 ___
 
@@ -98,7 +98,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L94)
 
 ___
 
@@ -118,4 +118,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.Disabled.md
+++ b/docs/interfaces/TestFs.Disabled.md
@@ -15,7 +15,7 @@
 
 ### <a id="enable" name="enable"></a> enable
 
-▸ **enable**(): `Promise`<[`Enabled`](TestFs.Enabled.md)\>
+▸ **enable**(): `Promise`\<[`Enabled`](TestFs.Enabled.md)\>
 
 Setup the test environment with the provided test configurations
 
@@ -29,17 +29,17 @@ Note that attempts to call the setup function more than once will cause an excep
 
 #### Returns
 
-`Promise`<[`Enabled`](TestFs.Enabled.md)\>
+`Promise`\<[`Enabled`](TestFs.Enabled.md)\>
 
 #### Defined in
 
-[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L154)
+[testfs/types.ts:154](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L154)
 
 ___
 
 ### <a id="restore" name="restore"></a> restore
 
-▸ **restore**(): `Promise`<[`Disabled`](TestFs.Disabled.md)\>
+▸ **restore**(): `Promise`\<[`Disabled`](TestFs.Disabled.md)\>
 
 If the instance has been enabled, restore the environment to the
 state before the filesystem was setup
@@ -49,8 +49,8 @@ been restored.
 
 #### Returns
 
-`Promise`<[`Disabled`](TestFs.Disabled.md)\>
+`Promise`\<[`Disabled`](TestFs.Disabled.md)\>
 
 #### Defined in
 
-[testfs/types.ts:163](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L163)
+[testfs/types.ts:163](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L163)

--- a/docs/interfaces/TestFs.Enabled.md
+++ b/docs/interfaces/TestFs.Enabled.md
@@ -29,30 +29,30 @@ Id of the testfs instance
 
 #### Defined in
 
-[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L115)
+[testfs/types.ts:115](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L115)
 
 ## Methods
 
 ### <a id="cleanup" name="cleanup"></a> cleanup
 
-▸ **cleanup**(): `Promise`<[`Enabled`](TestFs.Enabled.md)\>
+▸ **cleanup**(): `Promise`\<[`Enabled`](TestFs.Enabled.md)\>
 
 Remove any files modified by the test as specified in the
 testfs `cleanup` configuration.
 
 #### Returns
 
-`Promise`<[`Enabled`](TestFs.Enabled.md)\>
+`Promise`\<[`Enabled`](TestFs.Enabled.md)\>
 
 #### Defined in
 
-[testfs/types.ts:130](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L130)
+[testfs/types.ts:130](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L130)
 
 ___
 
 ### <a id="restore" name="restore"></a> restore
 
-▸ **restore**(): `Promise`<[`Disabled`](TestFs.Disabled.md)\>
+▸ **restore**(): `Promise`\<[`Disabled`](TestFs.Disabled.md)\>
 
 Restore the environment to the state before the filesystem was setup
 
@@ -62,8 +62,8 @@ The following operations are performed during restore
 
 #### Returns
 
-`Promise`<[`Disabled`](TestFs.Disabled.md)\>
+`Promise`\<[`Disabled`](TestFs.Disabled.md)\>
 
 #### Defined in
 
-[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L124)
+[testfs/types.ts:124](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L124)

--- a/docs/interfaces/TestFs.FileOpts.md
+++ b/docs/interfaces/TestFs.FileOpts.md
@@ -37,7 +37,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L21)
 
 ___
 
@@ -53,7 +53,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L42)
 
 ___
 
@@ -69,7 +69,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L28)
 
 ___
 
@@ -83,4 +83,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileRef.md
+++ b/docs/interfaces/TestFs.FileRef.md
@@ -41,7 +41,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ path is given, `process.cwd()` will be used as basedir
 
 #### Defined in
 
-[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L61)
+[testfs/types.ts:61](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L61)
 
 ___
 
@@ -74,7 +74,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L42)
 
 ___
 
@@ -94,7 +94,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L28)
 
 ___
 
@@ -112,4 +112,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.FileSpec.md
+++ b/docs/interfaces/TestFs.FileSpec.md
@@ -40,7 +40,7 @@ Last access time for the file.
 
 #### Defined in
 
-[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L21)
+[testfs/types.ts:21](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ Contents of the file
 
 #### Defined in
 
-[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L49)
+[testfs/types.ts:49](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L49)
 
 ___
 
@@ -72,7 +72,7 @@ Group id for the file
 
 #### Defined in
 
-[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L42)
+[testfs/types.ts:42](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L42)
 
 ___
 
@@ -92,7 +92,7 @@ Last modification time for the file.
 
 #### Defined in
 
-[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L28)
+[testfs/types.ts:28](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L28)
 
 ___
 
@@ -110,4 +110,4 @@ User id for the file
 
 #### Defined in
 
-[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L35)
+[testfs/types.ts:35](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L35)

--- a/docs/interfaces/TestFs.Opts.md
+++ b/docs/interfaces/TestFs.Opts.md
@@ -25,7 +25,7 @@
 
 • `Readonly` **basedir**: `string`
 
-Directory to use as base for search when calling [from](TestFs.TestFs.md#from)
+Directory to use as base for search when calling [TestFs.from](TestFs.TestFs.md#from)
 
 **`Default Value`**
 
@@ -33,7 +33,7 @@ given by the configuration in `.mochapodrc.yml`
 
 #### Defined in
 
-[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L79)
+[testfs/types.ts:79](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L79)
 
 ___
 
@@ -51,7 +51,7 @@ Add here any temporary files created during the test that should be cleaned up.
 
 #### Defined in
 
-[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L103)
+[testfs/types.ts:103](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L103)
 
 ___
 
@@ -69,7 +69,7 @@ filesystem. Any files that will be modified during the test should go here
 
 #### Defined in
 
-[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L94)
+[testfs/types.ts:94](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L94)
 
 ___
 
@@ -85,4 +85,4 @@ Directory to use as base for the directory specification and glob search.
 
 #### Defined in
 
-[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L86)
+[testfs/types.ts:86](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L86)

--- a/docs/interfaces/TestFs.TestFs.md
+++ b/docs/interfaces/TestFs.TestFs.md
@@ -12,7 +12,7 @@
 
 Create a disabled testfs configuration from the given directory spec.
 
-Calling the [enable](TestFs.Disabled.md#enable) method will prepare the filesystem for testing
+Calling the [TestFs.Disabled.enable](TestFs.Disabled.md#enable) method will prepare the filesystem for testing
 operations.
 
 **IMPORTANT** don't use this module in a real (non-containerized) system, specially with admin permissions, you risk leaving the system
@@ -22,8 +22,8 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `spec?` | [`Directory`](TestFs.Directory.md) | Directory specification with files that need to be               exist after set-up of the test fs. If the file exists previously               in the given location it will be added to the `keep` list for restoring later.               If it doesn't it will be added to the `cleanup` list to be removed during cleanup |
-| `opts?` | `Partial`<[`Opts`](TestFs.Opts.md)\> | Additional options for the test fs. |
+| `spec?` | [`Directory`](TestFs.Directory.md) | Directory specification with files that need to be exist after set-up of the test fs. If the file exists previously in the given location it will be added to the `keep` list for restoring later. If it doesn't it will be added to the `cleanup` list to be removed during cleanup |
+| `opts?` | `Partial`\<[`Opts`](TestFs.Opts.md)\> | Additional options for the test fs. |
 
 #### Returns
 
@@ -33,7 +33,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L183)
+[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L183)
 
 ## Table of contents
 
@@ -55,7 +55,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 | Name | Type |
 | :------ | :------ |
-| `conf` | `Partial`<[`Config`](TestFs.Config.md)\> |
+| `conf` | `Partial`\<[`Config`](TestFs.Config.md)\> |
 
 #### Returns
 
@@ -63,7 +63,7 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:190](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L190)
+[testfs/types.ts:190](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L190)
 
 ___
 
@@ -77,7 +77,7 @@ Create a file specification from a partial file description
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `f` | `string` \| `Buffer` \| `Partial`<[`FileSpec`](TestFs.FileSpec.md)\> | file contents or partial file specification |
+| `f` | `string` \| `Buffer` \| `Partial`\<[`FileSpec`](TestFs.FileSpec.md)\> | file contents or partial file specification |
 
 #### Returns
 
@@ -87,7 +87,7 @@ full file specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L215)
+[testfs/types.ts:215](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L215)
 
 ___
 
@@ -101,7 +101,7 @@ Create a file reference to an existing file
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `f` | `string` \| [`WithOptional`](../modules/TestFs.md#withoptional)<[`FileRef`](TestFs.FileRef.md), keyof [`FileOpts`](TestFs.FileOpts.md)\> | absolute or relative file path to create the reference from, if a relative path is given, `process.cwd()` will be            used as basedir. This parameter can also be a partial FileRef specification |
+| `f` | `string` \| [`WithOptional`](../modules/TestFs.md#withoptional)\<[`FileRef`](TestFs.FileRef.md), keyof [`FileOpts`](TestFs.FileOpts.md)\> | absolute or relative file path to create the reference from, if a relative path is given, `process.cwd()` will be used as basedir. This parameter can also be a partial FileRef specification |
 
 #### Returns
 
@@ -111,43 +111,43 @@ full file reference specification with defaults set
 
 #### Defined in
 
-[testfs/types.ts:224](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L224)
+[testfs/types.ts:224](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L224)
 
 ___
 
 ### <a id="leftovers" name="leftovers"></a> leftovers
 
-▸ **leftovers**(): `Promise`<`string`[]\>
+▸ **leftovers**(): `Promise`\<`string`[]\>
 
 Return any leftover backup files from previous invocations.
 
-If any leftovers exist prior to running [enable](TestFs.Disabled.md#enable)
+If any leftovers exist prior to running [TestFs.Disabled.enable](TestFs.Disabled.md#enable)
 it means that a previous invocation did not terminate succesfully and is not
 safe to run the setup.
 
 #### Returns
 
-`Promise`<`string`[]\>
+`Promise`\<`string`[]\>
 
 #### Defined in
 
-[testfs/types.ts:207](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L207)
+[testfs/types.ts:207](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L207)
 
 ___
 
 ### <a id="restore" name="restore"></a> restore
 
-▸ **restore**(): `Promise`<`void`\>
+▸ **restore**(): `Promise`\<`void`\>
 
 Restore testsfs globally.
 
 This function looks for a currently enabled instance of a test filesystem and calls
-[restore](TestFs.Enabled.md#restore) on that instance.
+[TestFs.Enabled.restore](TestFs.Enabled.md#restore) on that instance.
 
 #### Returns
 
-`Promise`<`void`\>
+`Promise`\<`void`\>
 
 #### Defined in
 
-[testfs/types.ts:198](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L198)
+[testfs/types.ts:198](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L198)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -21,7 +21,7 @@
 
 Create a disabled testfs configuration from the given directory spec.
 
-Calling the [enable](interfaces/TestFs.Disabled.md#enable) method will prepare the filesystem for testing
+Calling the [TestFs.Disabled.enable](interfaces/TestFs.Disabled.md#enable) method will prepare the filesystem for testing
 operations.
 
 **IMPORTANT** don't use this module in a real (non-containerized) system, specially with admin permissions, you risk leaving the system
@@ -31,8 +31,8 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `spec?` | [`Directory`](interfaces/TestFs.Directory.md) | Directory specification with files that need to be               exist after set-up of the test fs. If the file exists previously               in the given location it will be added to the `keep` list for restoring later.               If it doesn't it will be added to the `cleanup` list to be removed during cleanup |
-| `opts?` | `Partial`<[`Opts`](interfaces/TestFs.Opts.md)\> | Additional options for the test fs. |
+| `spec?` | [`Directory`](interfaces/TestFs.Directory.md) | Directory specification with files that need to be exist after set-up of the test fs. If the file exists previously in the given location it will be added to the `keep` list for restoring later. If it doesn't it will be added to the `cleanup` list to be removed during cleanup |
+| `opts?` | `Partial`\<[`Opts`](interfaces/TestFs.Opts.md)\> | Additional options for the test fs. |
 
 #### Returns
 
@@ -42,4 +42,4 @@ in an inconsistent state if a crash happens before a `restore()` can be performe
 
 #### Defined in
 
-[testfs/types.ts:183](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L183)
+[testfs/testfs.ts:294](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/testfs.ts#L294)

--- a/docs/modules/MochaPod.md
+++ b/docs/modules/MochaPod.md
@@ -20,7 +20,7 @@
 
 ### <a id="default" name="default"></a> default
 
-Renames and re-exports [Config](MochaPod.md#config)
+Renames and re-exports [Config](MochaPod.md#config-1)
 
 ## Type Aliases
 
@@ -36,50 +36,50 @@ Renames and re-exports [Config](MochaPod.md#config)
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `basedir` | `string` | Base directory where configuration files are looked for. If a relative path is used, it is asumed to be relative to `process.cwd()`.  **`Default Value`**  `process.cwd()` |
-| `buildOnly` | `boolean` | Only perform the build step during the global mocha setup. If set to false this will run `npm run test` inside a container after the build.  **`Default Value`**  `false` |
-| `deviceArch` | `string` | The architecture of the system where the images will be built and ran. This is used to replace `%%BALENA_ARCH%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works)  The architecture is detected automatically using `uname`, set this value if building on a device other than the local machine.  Supported values: `'amd64' \| 'aarch64' \| 'armv7hf' \| 'i386' \| 'rpi'`  **`Default Value`**  inferred from `process.arch` |
-| `deviceType` | `string` | The device type of the system where the images will be built an ran. This is used to replace `%%BALENA_MACHINE_NAME%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works) given.  The device type is inferred automatically from the device architecture, set this value if building on a device other than the local machine. |
-| `dockerBuildOpts` | { `[key: string]`: `any`;  } | Extra options to pass to the image build. See https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageBuild  **`Default Value`**  `{   buildArgs: {     NODE_VERSION // the host environment node version    NODE_VERSION_MAJOR // the host environment major node version    BALENA_ARCH // the host architecture or the configuration value set by the user    BALENA_MACHINE_NAME // the machine name as set by the user or inferred from the architecture   } }` |
-| `dockerHost` | `string` | IP address or URL for the docker host. If no protocol is included, the protocol is assumed to be `tcp://` e.g. - `tcp://192.168.1.105` - `unix:///var/run/docker.sock`  The configuration value can be overriden by setting the `DOCKER_HOST` environment variable.  **`Default Value`**  `unix:///var/run/docker.sock` |
-| `dockerIgnore` | `string`[] | List of default dockerignore directives. These are overriden if a `.dockerignore` file is defined at the project root.  NOTE: `*/*//.git` is always ignored  **`Default Value`**  `['!*/*//Dockerfile', '!*/*//Dockerfile.*/', '*/*//node_modules', '*/*//build', '*/*//coverage' ]` |
-| `logging` | `string` | Log namespaces to enable. This can also be controlled via the `DEBUG` env var.  See https://github.com/debug-js/debug  **`Default Value`**  `'mocha-pod,mocha-pod:error'` |
+| `basedir` | `string` | Base directory where configuration files are looked for. If a relative path is used, it is asumed to be relative to `process.cwd()`. **`Default Value`** `process.cwd()` |
+| `buildOnly` | `boolean` | Only perform the build step during the global mocha setup. If set to false this will run `npm run test` inside a container after the build. **`Default Value`** `false` |
+| `deviceArch` | `string` | The architecture of the system where the images will be built and ran. This is used to replace `%%BALENA_ARCH%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works) The architecture is detected automatically using `uname`, set this value if building on a device other than the local machine. Supported values: `'amd64' \| 'aarch64' \| 'armv7hf' \| 'i386' \| 'rpi'` **`Default Value`** inferred from `process.arch` |
+| `deviceType` | `string` | The device type of the system where the images will be built an ran. This is used to replace `%%BALENA_MACHINE_NAME%%` in [Dockerfile.template](https://www.balena.io/docs/reference/base-images/base-images/#how-the-image-naming-scheme-works) given. The device type is inferred automatically from the device architecture, set this value if building on a device other than the local machine. |
+| `dockerBuildOpts` | \{ `[key: string]`: `any`;  } | Extra options to pass to the image build. See https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageBuild **`Default Value`** `{ buildargs: { NODE_VERSION // the host environment node version NODE_VERSION_MAJOR // the host environment major node version BALENA_ARCH // the host architecture or the configuration value set by the user BALENA_MACHINE_NAME // the machine name as set by the user or inferred from the architecture } }` |
+| `dockerHost` | `string` | IP address or URL for the docker host. If no protocol is included, the protocol is assumed to be `tcp://` e.g. - `tcp://192.168.1.105` - `unix:///var/run/docker.sock` The configuration value can be overriden by setting the `DOCKER_HOST` environment variable. **`Default Value`** `unix:///var/run/docker.sock` |
+| `dockerIgnore` | `string`[] | List of default dockerignore directives. These are overriden if a `.dockerignore` file is defined at the project root. NOTE: `*/*//.git` is always ignored **`Default Value`** `['!*/*//Dockerfile', '!*/*//Dockerfile.*/', '*/*//node_modules', '*/*//build', '*/*//coverage' ]` |
+| `logging` | `string` | Log namespaces to enable. This can also be controlled via the `DEBUG` env var. See https://github.com/debug-js/debug **`Default Value`** `'mocha-pod,mocha-pod:error'` |
 | `projectName` | `string` | Name of the project where mocha-pod is being ran on. By default it will get the name from `package.json` at `basedir`, if it does not exist, it will use `mocha-pod-testing` |
-| `testCommand` | `string`[] | Test command to use when running tests within a container. This will only be used if `buildOnly` is set to `false`.  **`Default Value`**  `["npm", "run", "test"]` |
-| `testfs` | `Partial`<`Omit`<[`Config`](../interfaces/TestFs.Config.md), ``"basedir"``\>\> | TestFs configuration to be set by the `beforeAll` mocha-pod hook.  **`Default Value`**  `{}` |
+| `testCommand` | `string`[] | Test command to use when running tests within a container. This will only be used if `buildOnly` is set to `false`. **`Default Value`** `["npm", "run", "test"]` |
+| `testfs` | `Partial`\<`Omit`\<[`Config`](../interfaces/TestFs.Config.md), ``"basedir"``\>\> | TestFs configuration to be set by the `beforeAll` mocha-pod hook. **`Default Value`** `{}` |
 
 #### Defined in
 
-[config.ts:225](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/config.ts#L225)
+[config.ts:225](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/config.ts#L225)
 
-[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/config.ts#L13)
+[config.ts:13](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/config.ts#L13)
 
 ## Functions
 
 ### <a id="config-1" name="config-1"></a> Config
 
-▸ **Config**(`overrides?`, `source?`): `Promise`<[`Config`](MochaPod.md#config)\>
+▸ **Config**(`overrides?`, `source?`): `Promise`\<[`Config`](MochaPod.md#config)\>
 
 Loads a mocha-pod configuration from the given source file and
 overrides the default values
-
-**`Default Value`**
-
-`path.join(process.cwd(), '.mochapodrc.yml')`
 
 #### Parameters
 
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
-| `overrides` | `Partial`<[`Config`](MochaPod.md#config)\> | `{}` | additional overrides. These take precedence over `.mochapodrc.yml` |
+| `overrides` | `Partial`\<[`Config`](MochaPod.md#config)\> | `{}` | additional overrides. These take precedence over `.mochapodrc.yml` |
 | `source` | `string` | `MOCHAPOD_CONFIG` | full path to look for the configuration file. |
 
 #### Returns
 
-`Promise`<[`Config`](MochaPod.md#config)\>
+`Promise`\<[`Config`](MochaPod.md#config)\>
 
 - updated mocha pod config including user overrides.
 
+**`Default Value`**
+
+`path.join(process.cwd(), '.mochapodrc.yml')`
+
 #### Defined in
 
-[config.ts:225](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/config.ts#L225)
+[config.ts:225](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/config.ts#L225)

--- a/docs/modules/TestFs.md
+++ b/docs/modules/TestFs.md
@@ -40,7 +40,7 @@ Re-exports [testfs](../modules.md#testfs)
 
 #### Defined in
 
-[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L64)
+[testfs/types.ts:64](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L64)
 
 ___
 
@@ -52,13 +52,13 @@ Describe a file contents
 
 #### Defined in
 
-[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L10)
+[testfs/types.ts:10](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L10)
 
 ___
 
 ### <a id="withoptional" name="withoptional"></a> WithOptional
 
-Ƭ **WithOptional**<`T`, `K`\>: `Omit`<`T`, `K`\> & `Partial`<`Pick`<`T`, `K`\>\>
+Ƭ **WithOptional**\<`T`, `K`\>: `Omit`\<`T`, `K`\> & `Partial`\<`Pick`\<`T`, `K`\>\>
 
 Utility type to mark only some properties of a given type as optional
 
@@ -71,4 +71,4 @@ Utility type to mark only some properties of a given type as optional
 
 #### Defined in
 
-[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/83469cb/lib/testfs/types.ts#L4)
+[testfs/types.ts:4](https://github.com/balena-io-modules/mocha-pod/blob/906bf95/lib/testfs/types.ts#L4)

--- a/lib/attach/fixtures.ts
+++ b/lib/attach/fixtures.ts
@@ -1,9 +1,9 @@
 import { build, resolve as Resolve } from '@balena/compose';
 import dockerIgnore from '@balena/dockerignore';
-import * as Docker from 'dockerode';
+import Docker from 'dockerode';
 import { promises as fs } from 'fs';
-import * as readline from 'readline';
-import * as path from 'path';
+import readline from 'readline';
+import path from 'path';
 import * as tar from 'tar-fs';
 
 import logger from '../logger';

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -3,7 +3,7 @@ import * as YAML from 'js-yaml';
 import * as path from 'path';
 import logger from './logger';
 
-import * as TestFs from './testfs';
+import type * as TestFs from './testfs';
 
 import { exec as execSync } from 'child_process';
 import { promisify } from 'util';
@@ -208,10 +208,10 @@ function slugify(text: string) {
 		.toString() // Cast to string (optional)
 		.normalize('NFKD') // The normalize() using NFKD method returns the Unicode Normalization Form of a given string.
 		.toLowerCase() // Convert the string to lowercase letters
-		.replace(/[^\w\-]+/g, ' ') // Replace all non-word chars with ' '
+		.replace(/[^\w-]+/g, ' ') // Replace all non-word chars with ' '
 		.trim() // Remove whitespace from both sides of a string (optional)
 		.replace(/\s+/g, '-') // Replace spaces with -
-		.replace(/\-\-+/g, '-'); // Replace multiple - with single -
+		.replace(/--+/g, '-'); // Replace multiple - with single -
 }
 
 /**

--- a/lib/testfs/testfs.ts
+++ b/lib/testfs/testfs.ts
@@ -1,6 +1,6 @@
-import * as fg from 'fast-glob';
-import * as os from 'os';
-import * as path from 'path';
+import fg from 'fast-glob';
+import os from 'os';
+import path from 'path';
 import * as tar from 'tar-fs';
 import logger from '../logger';
 import { strict as assert } from 'assert';
@@ -9,7 +9,7 @@ import { BetterLock } from 'better-lock';
 import { createReadStream, createWriteStream, promises as fs } from 'fs';
 import { flatten, replace, fileRef, fileSpec } from './utils';
 
-import {
+import type {
 	Config,
 	Directory,
 	Disabled,

--- a/lib/testfs/utils.spec.ts
+++ b/lib/testfs/utils.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '~/testing';
 
 import { promises as fs } from 'fs';
-import * as mock from 'mock-fs';
+import mock from 'mock-fs';
 import { dir, flatten, replace, fileRef, fileSpec } from './utils';
 
 describe('testfs/utils: unit tests', function () {

--- a/lib/testfs/utils.ts
+++ b/lib/testfs/utils.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 
-import {
+import type {
 	Directory,
 	File,
 	FileRef,
@@ -136,7 +136,7 @@ function normalize(child: Directory, parent = '.'): Directory {
 			...normalized,
 			[location]: isDirectory(contents)
 				? // Normalize the directory recursively
-				  normalize(contents, path.join(parent, location))
+					normalize(contents, path.join(parent, location))
 				: contents,
 		};
 	}, {} as Directory);

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepack": "npm run build"
   },
   "devDependencies": {
-    "@balena/lint": "^6.0.0",
+    "@balena/lint": "^7.3.0",
     "@types/chai": "^4.2.18",
     "@types/chai-as-promised": "^7.1.4",
     "@types/debug": "^4.1.7",
@@ -68,9 +68,9 @@
     "rimraf": "^5.0.0",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.0.0",
-    "typedoc": "^0.24.0",
+    "typedoc": "^0.25.11",
     "typedoc-plugin-markdown": "^3.13.4",
-    "typescript": "^5.0.0"
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "@balena/compose": "^3.0.0",

--- a/tests/chai.ts
+++ b/tests/chai.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 
 export default chai;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"baseUrl": "./",
-		"module": "commonjs",
+		"module": "Node16",
 		"outDir": "build",
 		"noUnusedParameters": true,
 		"noUnusedLocals": true,
@@ -13,9 +13,16 @@
 		"declaration": true,
 		"skipLibCheck": true,
 		"paths": {
-			"~/mocha-pod": ["lib/index.ts"],
-			"~/testing": ["tests/index.ts"]
+			"~/mocha-pod": [
+				"lib/index.ts"
+			],
+			"~/testing": [
+				"tests/index.ts"
+			]
 		}
 	},
-	"include": ["lib/**/*.ts", "tests/**/*.ts"]
+	"include": [
+		"lib/**/*.ts",
+		"tests/**/*.ts"
+	]
 }


### PR DESCRIPTION
This also required to bump typescript to 5.3.3 and typedoc to the latest version. Documentation has been re-generated with this latest version

Change-type: patch