### PR TITLE
Bump tar-fs to 2.1.4

### DIFF
--- a/lib/attach/fixtures.ts
+++ b/lib/attach/fixtures.ts
@@ -54,9 +54,9 @@ async function writeCache(stageIds: string[], cachePath: string) {
 		});
 
 		// Write stage ids as cache for next build. Ignore any errors
-		await fs
-			.writeFile(cachePath, JSON.stringify(stageIds))
-			.catch((e) => logger.debug(`Could not write cache: ${e.message}`));
+		await fs.writeFile(cachePath, JSON.stringify(stageIds)).catch((e) => {
+			logger.debug(`Could not write cache: ${e.message}`);
+		});
 	}
 }
 
@@ -127,7 +127,7 @@ export async function mochaGlobalSetup() {
 		stageIds: string[];
 	}>((resolve) => {
 		// Store the stage ids for caching
-		const ids = [] as string[];
+		const ids: string[] = [];
 
 		const hooks = {
 			buildStream: (input: NodeJS.ReadWriteStream): void => {

--- a/lib/attach/hooks.ts
+++ b/lib/attach/hooks.ts
@@ -23,8 +23,8 @@ export const mochaHooks = {
 						contents.trim() !== '0::/' &&
 						lines
 							.map((l) => l.split(':'))
-							.filter(([, , entry]) => entry && entry.startsWith('/docker'))
-							.length === 0
+							.filter(([, , entry]) => entry?.startsWith('/docker')).length ===
+							0
 					) {
 						// Throw a place holder error
 						throw new Error();

--- a/lib/testfs/testfs.ts
+++ b/lib/testfs/testfs.ts
@@ -61,7 +61,7 @@ const lock = (() => {
 
 	// Stack of currently locked instances.
 	// only the top of the stack can be restored
-	const stack = [] as Enabled[];
+	const stack: Enabled[] = [];
 
 	const releaseAll = async () => {
 		while (stack.length > 0) {
@@ -199,7 +199,9 @@ function build(
 						})
 						.pipe(createWriteStream(filename));
 
-					stream.on('finish', () => resolve(filename));
+					stream.on('finish', () => {
+						resolve(filename);
+					});
 				});
 
 				// Create the restore function to be used in case of any errors

--- a/lib/testfs/testfs.ts
+++ b/lib/testfs/testfs.ts
@@ -217,7 +217,12 @@ function build(
 					// Now restore the files from the backup
 					await new Promise((resolve) =>
 						createReadStream(tarFile)
-							.pipe(tar.extract(rootdir))
+							.pipe(
+								tar.extract(rootdir, {
+									validateSymlinks: false,
+									// TODO: This isn't typed in @types/tar-fs yet
+								} as tar.ExtractOptions),
+							)
 							.on('finish', resolve),
 					);
 					debug('restore: recovered', toKeep);

--- a/lib/testfs/utils.ts
+++ b/lib/testfs/utils.ts
@@ -79,7 +79,7 @@ function normalize(child: Directory, parent = '.'): Directory {
 			return [relPath, contents];
 		})
 		// Group the directories by the first path element
-		.reduce((normalized, [location, contents]) => {
+		.reduce<Directory>((normalized, [location, contents]) => {
 			const [basedir, ...rest] = location.split(path.sep);
 
 			// If the path resolution in the previous step returns ''
@@ -127,10 +127,10 @@ function normalize(child: Directory, parent = '.'): Directory {
 				...normalized,
 				[basedir]: rest.length > 0 ? { [file]: contents } : contents,
 			};
-		}, {} as Directory);
+		}, {});
 
 	// Recursively normalize the subdirectories
-	return Object.keys(grouped).reduce((normalized, location) => {
+	return Object.keys(grouped).reduce<Directory>((normalized, location) => {
 		const contents = grouped[location];
 		return {
 			...normalized,
@@ -139,7 +139,7 @@ function normalize(child: Directory, parent = '.'): Directory {
 					normalize(contents, path.join(parent, location))
 				: contents,
 		};
-	}, {} as Directory);
+	}, {});
 }
 
 /**
@@ -285,12 +285,12 @@ function flatList(root: Directory, parent = '/'): Array<[string, File]> {
  * ```
  */
 export function flatten(root: Directory): Directory {
-	return flatList(normalize(root)).reduce(
+	return flatList(normalize(root)).reduce<Directory>(
 		(res, [filename, contents]) => ({
 			...res,
 			[filename]: contents,
 		}),
-		{} as Directory,
+		{},
 	);
 }
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^10.0.0",
     "@types/mock-fs": "^4.13.1",
-    "@types/tar-fs": "^2.0.1",
+    "@types/tar-fs": "^2.0.4",
     "@types/tar-stream": "^3.0.0",
     "balena-config-karma": "^4.0.0",
     "chai": "^4.3.4",
@@ -81,7 +81,7 @@
     "fast-glob": "^3.2.11",
     "js-yaml": "^4.1.0",
     "nanoid": "^5.0.9",
-    "tar-fs": "^2.1.1"
+    "tar-fs": "^2.1.4"
   },
   "versionist": {
     "publishedAt": "2025-02-28T17:13:38.942Z"


### PR DESCRIPTION
tar-fs 2.1.4 adds symlink validation to mitigate CVE-2025-59343. Symlink validation causes tests
to fail under certain conditions in balena-supervisor, which is a consumer of mocha-pod.

See: https://github.com/mafintosh/tar-fs/security/advisories/GHSA-vj76-c3g6-qr5v
Change-type: patch